### PR TITLE
fix: allow hyphens in bluesky usernames

### DIFF
--- a/src/render/instantview.ts
+++ b/src/render/instantview.ts
@@ -26,7 +26,7 @@ const populateUserLinks = (text: string, status: APIStatus): string => {
   let usernamePattern = /@(\w{1,15})/g;
 
   if (status.provider === DataProvider.Bsky) {
-    usernamePattern = /@([\w.]+)/g;
+    usernamePattern = /@(?!-)([\w.-]+(?<!-))/g;
   }
 
   text.match(usernamePattern)?.forEach(match => {


### PR DESCRIPTION
This adds hyphens (`-`) to the user link populator for the instant view, which fixes that valid handles containing hyphens are only partially rendered.

Bluesky uses a [more comprehensive 92-character regex](https://github.com/bluesky-social/social-app/blob/118d385b1010190542e58fba1d640f75714b6ea9/src/lib/strings/handles.ts#L6), so we could also use that, but this PR keeps the regex just as lenient but adds hyphen support.

## Example

| Current | Bluesky |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/0ad5352e-f29e-47be-82f9-6580b63834fd) | ![image](https://github.com/user-attachments/assets/5b99101e-67ea-43d0-8002-9197b14c3745) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved username detection to prevent matching usernames that start or end with a hyphen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->