### PR TITLE
fix: fix redirect url with name flag

### DIFF
--- a/src/embed/status.ts
+++ b/src/embed/status.ts
@@ -4,7 +4,7 @@ import i18next from 'i18next';
 import icu from 'i18next-icu';
 import { Constants } from '../constants';
 import { handleQuote } from '../helpers/quote';
-import { sanitizeText, truncateWithEllipsis } from '../helpers/utils';
+import { formatImageUrl, sanitizeText, truncateWithEllipsis } from '../helpers/utils';
 import { Strings } from '../strings';
 import { getSocialProof } from '../helpers/socialproof';
 import { renderPhoto } from '../render/photo';
@@ -249,8 +249,8 @@ export const handleStatus = async (
         redirectUrl = `https://${Constants.API_HOST_LIST[0]}/2/go?url=${encodeURIComponent(redirectUrl)}`;
       }
       // Only append name if it's an image
-      if (/\.(png|jpe?g|gif)(\?|$)/.test(redirectUrl) && flags.name) {
-        redirectUrl = `${redirectUrl}:${flags.name}`;
+      if (selectedMedia?.type === 'photo' && flags.name) {
+        redirectUrl = formatImageUrl(redirectUrl, flags.name);
       }
       console.log('redirectUrl', redirectUrl);
       return c.redirect(redirectUrl, 302);

--- a/src/helpers/media.ts
+++ b/src/helpers/media.ts
@@ -10,7 +10,7 @@ export const processMedia = (c: Context, media: TweetMedia): APIPhoto | APIVideo
   if (media.type === 'photo') {
     return {
       type: 'photo',
-      url: formatImageUrl(media.media_url_https),
+      url: formatImageUrl(media.media_url_https, 'orig'),
       width: media.original_info?.width,
       height: media.original_info?.height,
       altText: media.ext_alt_text

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -77,11 +77,18 @@ export const escapeRegex = (text: string) => {
   return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 };
 
-export const formatImageUrl = (url: string) => {
+export const formatImageUrl = (url: string, name = 'orig') => {
   try {
-    const urlObj = new URL(url);
-    // add name=orig parameter to url
-    urlObj.searchParams.set('name', 'orig');
+    // remove existing name in url in case of conflicting
+    // e.g. https://pbs.twimg.com/media/foobar.jpg:orig
+    const urlObj = new URL(url.replace(/:\w+$/, ''));
+
+    if (name) {
+      // add name parameter to url
+      urlObj.searchParams.set('name', name);
+    } else {
+      urlObj.searchParams.delete('name');
+    }
     return urlObj.toString();
   } catch (_e) {
     return url;


### PR DESCRIPTION
Fixed a bug introduced in 5d1dcd7 (#1282). 

In a previous PR (#1116), FxEmbed supports using the name flag to control the image quality of direct link (d.fxtwitter.com). With the changes in 5d1dcd7, the redirect link is incorrect with a broken name parameter, just like what https://github.com/FxEmbed/FxEmbed/issues/1282#issuecomment-3283695657 said.

✔ https://d.fixupx.com/elonmusk/status/1884062175280668757→ https://pbs.twimg.com/media/GiWIkCVWEAA19SU.jpg?name=orig
❌ https://d.fixupx.com/elonmusk/status/1884062175280668757:orig → https://pbs.twimg.com/media/GiWIkCVWEAA19SU.jpg?name=orig:orig
❌ https://d.fixupx.com/elonmusk/status/1884062175280668757?name=orig → https://pbs.twimg.com/media/GiWIkCVWEAA19SU.jpg?name=orig:orig

The PR fixes the backward compatibility with existing name-flag-urls.