### PR TITLE
Hide about author section in Instagram Instant View

### DIFF
--- a/src/render/instantview.ts
+++ b/src/render/instantview.ts
@@ -246,7 +246,9 @@ const generateStatusFooter = (
         ? `<a href="${status.url}">${i18next.t('ivViewOriginal')}</a>`
         : notApplicableComment,
     aboutSection:
-      isQuote || status.provider === DataProvider.Bluesky
+      isQuote ||
+      status.provider === DataProvider.Bluesky ||
+      status.provider === DataProvider.Instagram
         ? ''
         : `<h2>${i18next.t('ivAboutAuthor')}</h2>
         {pfp}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Omit the Instant View “About author” footer for Instagram posts, matching Bluesky.
- Instagram author/profile fields are still incomplete, so showing that section is misleading until fuller details are available.

## Test plan
- [ ] Request Instant View for an Instagram post (e.g. Instant View subdomain / force Instant View) and confirm the about-author block is absent.
- [ ] Confirm Twitter Instant View still shows the about-author section.
- [ ] Confirm Bluesky Instant View still hides it.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff156-d00d-7531-9a67-f4ec5e857538?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff156-d00d-7531-9a67-f4ec5e857538&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the “About Author” section from Instagram Instant View statuses, matching the behavior for quotes and Bluesky statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->