### PR TITLE
Enable Telegram Instant View for posts with multiple videos

### DIFF
--- a/src/embed/status.ts
+++ b/src/embed/status.ts
@@ -261,6 +261,7 @@ export const handleStatus = async (
       !!(
         status.media?.photos?.[0] || // Force instant view for photos for now https://bugs.telegram.org/c/33679
         status.media?.mosaic ||
+        (status.media?.videos?.length ?? 0) > 1 || // Telegram only previews one video; IV lists the rest
         (status.quote && !isTombstone(status.quote)) ||
         flags?.forceInstantView ||
         (status as APITwitterStatus)?.article ||

--- a/test/mocks/TweetDetail/991610.json
+++ b/test/mocks/TweetDetail/991610.json
@@ -1,0 +1,534 @@
+{
+  "data": {
+    "threaded_conversation_with_injections_v2": {
+      "instructions": [
+        {
+          "type": "TimelineAddEntries",
+          "entries": [
+            {
+              "entryId": "tweet-991610",
+              "sortIndex": "7382165761766485528",
+              "content": {
+                "entryType": "TimelineTimelineItem",
+                "__typename": "TimelineTimelineItem",
+                "itemContent": {
+                  "itemType": "TimelineTweet",
+                  "__typename": "TimelineTweet",
+                  "tweet_results": {
+                    "result": {
+                      "__typename": "Tweet",
+                      "rest_id": "991610",
+                      "has_birdwatch_notes": false,
+                      "core": {
+                        "user_results": {
+                          "result": {
+                            "__typename": "User",
+                            "id": "VXNlcjo5NzQwNjcxOTAzODYxNDczMjk=",
+                            "rest_id": "974067190386147329",
+                            "affiliates_highlighted_label": {},
+                            "has_graduated_access": true,
+                            "parody_commentary_fan_label": "None",
+                            "is_blue_verified": false,
+                            "profile_image_shape": "Circle",
+                            "legacy": {
+                              "following": false,
+                              "can_dm": false,
+                              "can_media_tag": false,
+                              "created_at": "Wed Mar 14 23:38:10 +0000 2018",
+                              "default_profile": false,
+                              "default_profile_image": false,
+                              "description": "Lover of this land from desert to sea. \nAmateur wildlife photographer, mostly native birdlife. \nAll photographs posted are my original images except reposts.",
+                              "entities": {
+                                "description": {
+                                  "urls": []
+                                },
+                                "url": {
+                                  "urls": [
+                                    {
+                                      "display_url": "instagram.com/divine_dropbea…",
+                                      "expanded_url": "https://www.instagram.com/divine_dropbear/",
+                                      "url": "https://t.co/N0ForImxXd",
+                                      "indices": [
+                                        0,
+                                        23
+                                      ]
+                                    }
+                                  ]
+                                }
+                              },
+                              "fast_followers_count": 0,
+                              "favourites_count": 25601,
+                              "followers_count": 2516,
+                              "friends_count": 1508,
+                              "has_custom_timelines": false,
+                              "is_translator": false,
+                              "listed_count": 32,
+                              "location": "@divinedropbear.bsky.social ",
+                              "media_count": 1248,
+                              "name": "Tranquility Found",
+                              "normal_followers_count": 2516,
+                              "pinned_tweet_ids_str": [],
+                              "possibly_sensitive": false,
+                              "profile_banner_url": "https://pbs.twimg.com/profile_banners/974067190386147329/1533093346",
+                              "profile_image_url_https": "https://pbs.twimg.com/profile_images/1871316427581583360/AY58qda4_normal.jpg",
+                              "profile_interstitial_type": "",
+                              "screen_name": "DivineDropbear",
+                              "statuses_count": 11954,
+                              "translator_type": "none",
+                              "url": "https://t.co/N0ForImxXd",
+                              "verified": false,
+                              "want_retweets": false,
+                              "withheld_in_countries": []
+                            },
+                            "tipjar_settings": {}
+                          }
+                        }
+                      },
+                      "unmention_data": {},
+                      "edit_control": {
+                        "edit_tweet_ids": [
+                          "991610"
+                        ],
+                        "editable_until_msecs": "1727816358000",
+                        "is_edit_eligible": true,
+                        "edits_remaining": "5"
+                      },
+                      "is_translatable": false,
+                      "views": {
+                        "count": "4186",
+                        "state": "EnabledWithCount"
+                      },
+                      "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+                      "grok_analysis_button": true,
+                      "legacy": {
+                        "bookmark_count": 7,
+                        "bookmarked": false,
+                        "created_at": "Tue Oct 01 19:59:18 +0000 2024",
+                        "conversation_id_str": "991610",
+                        "display_text_range": [
+                          0,
+                          162
+                        ],
+                        "entities": {
+                          "hashtags": [
+                            {
+                              "indices": [
+                                80,
+                                86
+                              ],
+                              "text": "birds"
+                            },
+                            {
+                              "indices": [
+                                87,
+                                100
+                              ],
+                              "text": "birdwatching"
+                            },
+                            {
+                              "indices": [
+                                101,
+                                109
+                              ],
+                              "text": "birding"
+                            },
+                            {
+                              "indices": [
+                                110,
+                                117
+                              ],
+                              "text": "WildOz"
+                            },
+                            {
+                              "indices": [
+                                118,
+                                134
+                              ],
+                              "text": "birdphotography"
+                            },
+                            {
+                              "indices": [
+                                135,
+                                152
+                              ],
+                              "text": "birdsofaustralia"
+                            },
+                            {
+                              "indices": [
+                                153,
+                                162
+                              ],
+                              "text": "cockatoo"
+                            }
+                          ],
+                          "media": [
+                            {
+                              "display_url": "pic.x.com/RoMxHhAo9X",
+                              "expanded_url": "https://example.invalid/DivineDropbear/status/991610/video/1",
+                              "id_str": "1841204388993646595",
+                              "indices": [
+                                163,
+                                186
+                              ],
+                              "media_key": "7_1841204388993646595",
+                              "media_url_https": "https://pbs.twimg.com/ext_tw_video_thumb/1841204388993646595/pu/img/KKN8tSQm60z2FmtE.jpg",
+                              "type": "video",
+                              "url": "https://t.co/RoMxHhAo9X",
+                              "additional_media_info": {
+                                "monetizable": false
+                              },
+                              "ext_media_availability": {
+                                "status": "Available"
+                              },
+                              "sizes": {
+                                "large": {
+                                  "h": 1080,
+                                  "w": 1920,
+                                  "resize": "fit"
+                                },
+                                "medium": {
+                                  "h": 675,
+                                  "w": 1200,
+                                  "resize": "fit"
+                                },
+                                "small": {
+                                  "h": 383,
+                                  "w": 680,
+                                  "resize": "fit"
+                                },
+                                "thumb": {
+                                  "h": 150,
+                                  "w": 150,
+                                  "resize": "crop"
+                                }
+                              },
+                              "original_info": {
+                                "height": 1080,
+                                "width": 1920,
+                                "focus_rects": []
+                              },
+                              "video_info": {
+                                "aspect_ratio": [
+                                  16,
+                                  9
+                                ],
+                                "duration_millis": 29626,
+                                "variants": [
+                                  {
+                                    "content_type": "application/x-mpegURL",
+                                    "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/pl/-kd3cWye2HXbiTju.m3u8?tag=12&v=cfc"
+                                  },
+                                  {
+                                    "bitrate": 256000,
+                                    "content_type": "video/mp4",
+                                    "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/480x270/vxKqarkYhJW80NBu.mp4?tag=12"
+                                  },
+                                  {
+                                    "bitrate": 832000,
+                                    "content_type": "video/mp4",
+                                    "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/640x360/gap6eNvJGCbYTOWH.mp4?tag=12"
+                                  },
+                                  {
+                                    "bitrate": 2176000,
+                                    "content_type": "video/mp4",
+                                    "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/1280x720/NRpzIavCR5W-jWFh.mp4?tag=12"
+                                  }
+                                ]
+                              },
+                              "media_results": {
+                                "result": {
+                                  "media_key": "7_1841204388993646595"
+                                }
+                              }
+                            },
+                            {
+                              "display_url": "pic.x.com/SecondVideo",
+                              "expanded_url": "https://example.invalid/DivineDropbear/status/991610/video/1",
+                              "id_str": "9916110000000000001",
+                              "indices": [
+                                163,
+                                186
+                              ],
+                              "media_key": "7_9916110000000000001",
+                              "media_url_https": "https://pbs.twimg.com/ext_tw_video_thumb/1841204388993646595/pu/img/KKN8tSQm60z2FmtE.jpg",
+                              "type": "video",
+                              "url": "https://t.co/SecondVideo",
+                              "additional_media_info": {
+                                "monetizable": false
+                              },
+                              "ext_media_availability": {
+                                "status": "Available"
+                              },
+                              "sizes": {
+                                "large": {
+                                  "h": 1080,
+                                  "w": 1920,
+                                  "resize": "fit"
+                                },
+                                "medium": {
+                                  "h": 675,
+                                  "w": 1200,
+                                  "resize": "fit"
+                                },
+                                "small": {
+                                  "h": 383,
+                                  "w": 680,
+                                  "resize": "fit"
+                                },
+                                "thumb": {
+                                  "h": 150,
+                                  "w": 150,
+                                  "resize": "crop"
+                                }
+                              },
+                              "original_info": {
+                                "height": 1080,
+                                "width": 1920,
+                                "focus_rects": []
+                              },
+                              "video_info": {
+                                "aspect_ratio": [
+                                  16,
+                                  9
+                                ],
+                                "duration_millis": 29626,
+                                "variants": [
+                                  {
+                                    "content_type": "application/x-mpegURL",
+                                    "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/pl/-kd3cWye2HXbiTju.m3u8?tag=12&v=cfc"
+                                  },
+                                  {
+                                    "bitrate": 256000,
+                                    "content_type": "video/mp4",
+                                    "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/480x270/vxKqarkYhJW80NBu.mp4?tag=12"
+                                  },
+                                  {
+                                    "bitrate": 832000,
+                                    "content_type": "video/mp4",
+                                    "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/640x360/gap6eNvJGCbYTOWH.mp4?tag=12"
+                                  },
+                                  {
+                                    "bitrate": 2176000,
+                                    "content_type": "video/mp4",
+                                    "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/1280x720/NRpzIavCR5W-jWFh.mp4?tag=12"
+                                  }
+                                ]
+                              },
+                              "media_results": {
+                                "result": {
+                                  "media_key": "7_9916110000000000001"
+                                }
+                              }
+                            }
+                          ],
+                          "symbols": [],
+                          "timestamps": [],
+                          "urls": [],
+                          "user_mentions": [
+                            {
+                              "id_str": "490232734",
+                              "name": "Fred O'Donnell",
+                              "screen_name": "fred_od_photo",
+                              "indices": [
+                                65,
+                                79
+                              ]
+                            }
+                          ]
+                        },
+                        "extended_entities": {
+                          "media": [
+                            {
+                              "display_url": "pic.x.com/RoMxHhAo9X",
+                              "expanded_url": "https://example.invalid/DivineDropbear/status/991610/video/1",
+                              "id_str": "1841204388993646595",
+                              "indices": [
+                                163,
+                                186
+                              ],
+                              "media_key": "7_1841204388993646595",
+                              "media_url_https": "https://pbs.twimg.com/ext_tw_video_thumb/1841204388993646595/pu/img/KKN8tSQm60z2FmtE.jpg",
+                              "type": "video",
+                              "url": "https://t.co/RoMxHhAo9X",
+                              "additional_media_info": {
+                                "monetizable": false
+                              },
+                              "ext_media_availability": {
+                                "status": "Available"
+                              },
+                              "sizes": {
+                                "large": {
+                                  "h": 1080,
+                                  "w": 1920,
+                                  "resize": "fit"
+                                },
+                                "medium": {
+                                  "h": 675,
+                                  "w": 1200,
+                                  "resize": "fit"
+                                },
+                                "small": {
+                                  "h": 383,
+                                  "w": 680,
+                                  "resize": "fit"
+                                },
+                                "thumb": {
+                                  "h": 150,
+                                  "w": 150,
+                                  "resize": "crop"
+                                }
+                              },
+                              "original_info": {
+                                "height": 1080,
+                                "width": 1920,
+                                "focus_rects": []
+                              },
+                              "video_info": {
+                                "aspect_ratio": [
+                                  16,
+                                  9
+                                ],
+                                "duration_millis": 29626,
+                                "variants": [
+                                  {
+                                    "content_type": "application/x-mpegURL",
+                                    "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/pl/-kd3cWye2HXbiTju.m3u8?tag=12&v=cfc"
+                                  },
+                                  {
+                                    "bitrate": 256000,
+                                    "content_type": "video/mp4",
+                                    "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/480x270/vxKqarkYhJW80NBu.mp4?tag=12"
+                                  },
+                                  {
+                                    "bitrate": 832000,
+                                    "content_type": "video/mp4",
+                                    "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/640x360/gap6eNvJGCbYTOWH.mp4?tag=12"
+                                  },
+                                  {
+                                    "bitrate": 2176000,
+                                    "content_type": "video/mp4",
+                                    "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/1280x720/NRpzIavCR5W-jWFh.mp4?tag=12"
+                                  }
+                                ]
+                              },
+                              "media_results": {
+                                "result": {
+                                  "media_key": "7_1841204388993646595"
+                                }
+                              }
+                            },
+                            {
+                              "display_url": "pic.x.com/SecondVideo",
+                              "expanded_url": "https://example.invalid/DivineDropbear/status/991610/video/1",
+                              "id_str": "9916110000000000001",
+                              "indices": [
+                                163,
+                                186
+                              ],
+                              "media_key": "7_9916110000000000001",
+                              "media_url_https": "https://pbs.twimg.com/ext_tw_video_thumb/1841204388993646595/pu/img/KKN8tSQm60z2FmtE.jpg",
+                              "type": "video",
+                              "url": "https://t.co/SecondVideo",
+                              "additional_media_info": {
+                                "monetizable": false
+                              },
+                              "ext_media_availability": {
+                                "status": "Available"
+                              },
+                              "sizes": {
+                                "large": {
+                                  "h": 1080,
+                                  "w": 1920,
+                                  "resize": "fit"
+                                },
+                                "medium": {
+                                  "h": 675,
+                                  "w": 1200,
+                                  "resize": "fit"
+                                },
+                                "small": {
+                                  "h": 383,
+                                  "w": 680,
+                                  "resize": "fit"
+                                },
+                                "thumb": {
+                                  "h": 150,
+                                  "w": 150,
+                                  "resize": "crop"
+                                }
+                              },
+                              "original_info": {
+                                "height": 1080,
+                                "width": 1920,
+                                "focus_rects": []
+                              },
+                              "video_info": {
+                                "aspect_ratio": [
+                                  16,
+                                  9
+                                ],
+                                "duration_millis": 29626,
+                                "variants": [
+                                  {
+                                    "content_type": "application/x-mpegURL",
+                                    "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/pl/-kd3cWye2HXbiTju.m3u8?tag=12&v=cfc"
+                                  },
+                                  {
+                                    "bitrate": 256000,
+                                    "content_type": "video/mp4",
+                                    "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/480x270/vxKqarkYhJW80NBu.mp4?tag=12"
+                                  },
+                                  {
+                                    "bitrate": 832000,
+                                    "content_type": "video/mp4",
+                                    "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/640x360/gap6eNvJGCbYTOWH.mp4?tag=12"
+                                  },
+                                  {
+                                    "bitrate": 2176000,
+                                    "content_type": "video/mp4",
+                                    "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/1280x720/NRpzIavCR5W-jWFh.mp4?tag=12"
+                                  }
+                                ]
+                              },
+                              "media_results": {
+                                "result": {
+                                  "media_key": "7_9916110000000000001"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        "favorite_count": 296,
+                        "favorited": false,
+                        "full_text": "Sulphur-crested Cockatoo enjoying the warm Brisbane breeze...   \n@fred_od_photo #birds #birdwatching #birding #WildOz #birdphotography #birdsofaustralia #cockatoo https://t.co/RoMxHhAo9X",
+                        "is_quote_status": false,
+                        "lang": "en",
+                        "possibly_sensitive": false,
+                        "possibly_sensitive_editable": true,
+                        "quote_count": 1,
+                        "reply_count": 2,
+                        "retweet_count": 68,
+                        "retweeted": false,
+                        "user_id_str": "974067190386147329",
+                        "id_str": "991610"
+                      },
+                      "quick_promote_eligibility": {
+                        "eligibility": "IneligibleUserUnauthorized"
+                      }
+                    }
+                  },
+                  "tweetDisplayType": "Tweet",
+                  "hasModeratedReplies": false
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "TimelineTerminateTimeline",
+          "direction": "Top"
+        }
+      ]
+    }
+  }
+}

--- a/test/mocks/TweetResultByRestId/991610.json
+++ b/test/mocks/TweetResultByRestId/991610.json
@@ -1,0 +1,508 @@
+{
+  "data": {
+    "tweetResult": {
+      "result": {
+        "__typename": "Tweet",
+        "rest_id": "991610",
+        "core": {
+          "user_results": {
+            "result": {
+              "__typename": "User",
+              "id": "VXNlcjo5NzQwNjcxOTAzODYxNDczMjk=",
+              "rest_id": "974067190386147329",
+              "affiliates_highlighted_label": {},
+              "parody_commentary_fan_label": "None",
+              "is_blue_verified": false,
+              "profile_image_shape": "Circle",
+              "legacy": {
+                "created_at": "Wed Mar 14 23:38:10 +0000 2018",
+                "default_profile": false,
+                "default_profile_image": false,
+                "description": "Lover of this land from desert to sea. \nAmateur wildlife photographer, mostly native birdlife. \nAll photographs posted are my original images except reposts.",
+                "entities": {
+                  "description": {
+                    "urls": []
+                  },
+                  "url": {
+                    "urls": [
+                      {
+                        "display_url": "instagram.com/divine_dropbea…",
+                        "expanded_url": "https://www.instagram.com/divine_dropbear/",
+                        "url": "https://t.co/N0ForImxXd",
+                        "indices": [
+                          0,
+                          23
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "fast_followers_count": 0,
+                "favourites_count": 25601,
+                "followers_count": 2516,
+                "friends_count": 1508,
+                "has_custom_timelines": false,
+                "is_translator": false,
+                "listed_count": 32,
+                "location": "@divinedropbear.bsky.social ",
+                "media_count": 1248,
+                "name": "Tranquility Found",
+                "normal_followers_count": 2516,
+                "pinned_tweet_ids_str": [],
+                "possibly_sensitive": false,
+                "profile_banner_url": "https://pbs.twimg.com/profile_banners/974067190386147329/1533093346",
+                "profile_image_url_https": "https://pbs.twimg.com/profile_images/1871316427581583360/AY58qda4_normal.jpg",
+                "profile_interstitial_type": "",
+                "screen_name": "DivineDropbear",
+                "statuses_count": 11954,
+                "translator_type": "none",
+                "url": "https://t.co/N0ForImxXd",
+                "verified": false,
+                "withheld_in_countries": []
+              },
+              "tipjar_settings": {
+                "is_enabled": false,
+                "bandcamp_handle": "",
+                "bitcoin_handle": "",
+                "cash_app_handle": "",
+                "ethereum_handle": "",
+                "gofundme_handle": "",
+                "patreon_handle": "",
+                "pay_pal_handle": "",
+                "venmo_handle": ""
+              }
+            }
+          }
+        },
+        "unmention_data": {},
+        "edit_control": {
+          "edit_tweet_ids": [
+            "991610"
+          ],
+          "editable_until_msecs": "1727816358000",
+          "is_edit_eligible": true,
+          "edits_remaining": "5"
+        },
+        "is_translatable": false,
+        "views": {
+          "count": "4186",
+          "state": "EnabledWithCount"
+        },
+        "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+        "grok_analysis_button": true,
+        "legacy": {
+          "bookmark_count": 7,
+          "bookmarked": false,
+          "created_at": "Tue Oct 01 19:59:18 +0000 2024",
+          "conversation_id_str": "991610",
+          "display_text_range": [
+            0,
+            162
+          ],
+          "entities": {
+            "hashtags": [
+              {
+                "indices": [
+                  80,
+                  86
+                ],
+                "text": "birds"
+              },
+              {
+                "indices": [
+                  87,
+                  100
+                ],
+                "text": "birdwatching"
+              },
+              {
+                "indices": [
+                  101,
+                  109
+                ],
+                "text": "birding"
+              },
+              {
+                "indices": [
+                  110,
+                  117
+                ],
+                "text": "WildOz"
+              },
+              {
+                "indices": [
+                  118,
+                  134
+                ],
+                "text": "birdphotography"
+              },
+              {
+                "indices": [
+                  135,
+                  152
+                ],
+                "text": "birdsofaustralia"
+              },
+              {
+                "indices": [
+                  153,
+                  162
+                ],
+                "text": "cockatoo"
+              }
+            ],
+            "media": [
+              {
+                "display_url": "pic.x.com/RoMxHhAo9X",
+                "expanded_url": "https://example.invalid/DivineDropbear/status/991610/video/1",
+                "id_str": "1841204388993646595",
+                "indices": [
+                  163,
+                  186
+                ],
+                "media_key": "7_1841204388993646595",
+                "media_url_https": "https://pbs.twimg.com/ext_tw_video_thumb/1841204388993646595/pu/img/KKN8tSQm60z2FmtE.jpg",
+                "type": "video",
+                "url": "https://t.co/RoMxHhAo9X",
+                "additional_media_info": {
+                  "monetizable": false
+                },
+                "ext_media_availability": {
+                  "status": "Available"
+                },
+                "sizes": {
+                  "large": {
+                    "h": 1080,
+                    "w": 1920,
+                    "resize": "fit"
+                  },
+                  "medium": {
+                    "h": 675,
+                    "w": 1200,
+                    "resize": "fit"
+                  },
+                  "small": {
+                    "h": 383,
+                    "w": 680,
+                    "resize": "fit"
+                  },
+                  "thumb": {
+                    "h": 150,
+                    "w": 150,
+                    "resize": "crop"
+                  }
+                },
+                "original_info": {
+                  "height": 1080,
+                  "width": 1920,
+                  "focus_rects": []
+                },
+                "video_info": {
+                  "aspect_ratio": [
+                    16,
+                    9
+                  ],
+                  "duration_millis": 29626,
+                  "variants": [
+                    {
+                      "content_type": "application/x-mpegURL",
+                      "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/pl/-kd3cWye2HXbiTju.m3u8?tag=12&v=cfc"
+                    },
+                    {
+                      "bitrate": 256000,
+                      "content_type": "video/mp4",
+                      "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/480x270/vxKqarkYhJW80NBu.mp4?tag=12"
+                    },
+                    {
+                      "bitrate": 832000,
+                      "content_type": "video/mp4",
+                      "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/640x360/gap6eNvJGCbYTOWH.mp4?tag=12"
+                    },
+                    {
+                      "bitrate": 2176000,
+                      "content_type": "video/mp4",
+                      "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/1280x720/NRpzIavCR5W-jWFh.mp4?tag=12"
+                    }
+                  ]
+                },
+                "media_results": {
+                  "result": {
+                    "media_key": "7_1841204388993646595"
+                  }
+                }
+              },
+              {
+                "display_url": "pic.x.com/SecondVideo",
+                "expanded_url": "https://example.invalid/DivineDropbear/status/991610/video/1",
+                "id_str": "9916110000000000001",
+                "indices": [
+                  163,
+                  186
+                ],
+                "media_key": "7_9916110000000000001",
+                "media_url_https": "https://pbs.twimg.com/ext_tw_video_thumb/1841204388993646595/pu/img/KKN8tSQm60z2FmtE.jpg",
+                "type": "video",
+                "url": "https://t.co/SecondVideo",
+                "additional_media_info": {
+                  "monetizable": false
+                },
+                "ext_media_availability": {
+                  "status": "Available"
+                },
+                "sizes": {
+                  "large": {
+                    "h": 1080,
+                    "w": 1920,
+                    "resize": "fit"
+                  },
+                  "medium": {
+                    "h": 675,
+                    "w": 1200,
+                    "resize": "fit"
+                  },
+                  "small": {
+                    "h": 383,
+                    "w": 680,
+                    "resize": "fit"
+                  },
+                  "thumb": {
+                    "h": 150,
+                    "w": 150,
+                    "resize": "crop"
+                  }
+                },
+                "original_info": {
+                  "height": 1080,
+                  "width": 1920,
+                  "focus_rects": []
+                },
+                "video_info": {
+                  "aspect_ratio": [
+                    16,
+                    9
+                  ],
+                  "duration_millis": 29626,
+                  "variants": [
+                    {
+                      "content_type": "application/x-mpegURL",
+                      "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/pl/-kd3cWye2HXbiTju.m3u8?tag=12&v=cfc"
+                    },
+                    {
+                      "bitrate": 256000,
+                      "content_type": "video/mp4",
+                      "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/480x270/vxKqarkYhJW80NBu.mp4?tag=12"
+                    },
+                    {
+                      "bitrate": 832000,
+                      "content_type": "video/mp4",
+                      "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/640x360/gap6eNvJGCbYTOWH.mp4?tag=12"
+                    },
+                    {
+                      "bitrate": 2176000,
+                      "content_type": "video/mp4",
+                      "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/1280x720/NRpzIavCR5W-jWFh.mp4?tag=12"
+                    }
+                  ]
+                },
+                "media_results": {
+                  "result": {
+                    "media_key": "7_9916110000000000001"
+                  }
+                }
+              }
+            ],
+            "symbols": [],
+            "timestamps": [],
+            "urls": [],
+            "user_mentions": [
+              {
+                "id_str": "490232734",
+                "name": "Fred O'Donnell",
+                "screen_name": "fred_od_photo",
+                "indices": [
+                  65,
+                  79
+                ]
+              }
+            ]
+          },
+          "extended_entities": {
+            "media": [
+              {
+                "display_url": "pic.x.com/RoMxHhAo9X",
+                "expanded_url": "https://example.invalid/DivineDropbear/status/991610/video/1",
+                "id_str": "1841204388993646595",
+                "indices": [
+                  163,
+                  186
+                ],
+                "media_key": "7_1841204388993646595",
+                "media_url_https": "https://pbs.twimg.com/ext_tw_video_thumb/1841204388993646595/pu/img/KKN8tSQm60z2FmtE.jpg",
+                "type": "video",
+                "url": "https://t.co/RoMxHhAo9X",
+                "additional_media_info": {
+                  "monetizable": false
+                },
+                "ext_media_availability": {
+                  "status": "Available"
+                },
+                "sizes": {
+                  "large": {
+                    "h": 1080,
+                    "w": 1920,
+                    "resize": "fit"
+                  },
+                  "medium": {
+                    "h": 675,
+                    "w": 1200,
+                    "resize": "fit"
+                  },
+                  "small": {
+                    "h": 383,
+                    "w": 680,
+                    "resize": "fit"
+                  },
+                  "thumb": {
+                    "h": 150,
+                    "w": 150,
+                    "resize": "crop"
+                  }
+                },
+                "original_info": {
+                  "height": 1080,
+                  "width": 1920,
+                  "focus_rects": []
+                },
+                "video_info": {
+                  "aspect_ratio": [
+                    16,
+                    9
+                  ],
+                  "duration_millis": 29626,
+                  "variants": [
+                    {
+                      "content_type": "application/x-mpegURL",
+                      "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/pl/-kd3cWye2HXbiTju.m3u8?tag=12&v=cfc"
+                    },
+                    {
+                      "bitrate": 256000,
+                      "content_type": "video/mp4",
+                      "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/480x270/vxKqarkYhJW80NBu.mp4?tag=12"
+                    },
+                    {
+                      "bitrate": 832000,
+                      "content_type": "video/mp4",
+                      "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/640x360/gap6eNvJGCbYTOWH.mp4?tag=12"
+                    },
+                    {
+                      "bitrate": 2176000,
+                      "content_type": "video/mp4",
+                      "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/1280x720/NRpzIavCR5W-jWFh.mp4?tag=12"
+                    }
+                  ]
+                },
+                "media_results": {
+                  "result": {
+                    "media_key": "7_1841204388993646595"
+                  }
+                }
+              },
+              {
+                "display_url": "pic.x.com/SecondVideo",
+                "expanded_url": "https://example.invalid/DivineDropbear/status/991610/video/1",
+                "id_str": "9916110000000000001",
+                "indices": [
+                  163,
+                  186
+                ],
+                "media_key": "7_9916110000000000001",
+                "media_url_https": "https://pbs.twimg.com/ext_tw_video_thumb/1841204388993646595/pu/img/KKN8tSQm60z2FmtE.jpg",
+                "type": "video",
+                "url": "https://t.co/SecondVideo",
+                "additional_media_info": {
+                  "monetizable": false
+                },
+                "ext_media_availability": {
+                  "status": "Available"
+                },
+                "sizes": {
+                  "large": {
+                    "h": 1080,
+                    "w": 1920,
+                    "resize": "fit"
+                  },
+                  "medium": {
+                    "h": 675,
+                    "w": 1200,
+                    "resize": "fit"
+                  },
+                  "small": {
+                    "h": 383,
+                    "w": 680,
+                    "resize": "fit"
+                  },
+                  "thumb": {
+                    "h": 150,
+                    "w": 150,
+                    "resize": "crop"
+                  }
+                },
+                "original_info": {
+                  "height": 1080,
+                  "width": 1920,
+                  "focus_rects": []
+                },
+                "video_info": {
+                  "aspect_ratio": [
+                    16,
+                    9
+                  ],
+                  "duration_millis": 29626,
+                  "variants": [
+                    {
+                      "content_type": "application/x-mpegURL",
+                      "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/pl/-kd3cWye2HXbiTju.m3u8?tag=12&v=cfc"
+                    },
+                    {
+                      "bitrate": 256000,
+                      "content_type": "video/mp4",
+                      "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/480x270/vxKqarkYhJW80NBu.mp4?tag=12"
+                    },
+                    {
+                      "bitrate": 832000,
+                      "content_type": "video/mp4",
+                      "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/640x360/gap6eNvJGCbYTOWH.mp4?tag=12"
+                    },
+                    {
+                      "bitrate": 2176000,
+                      "content_type": "video/mp4",
+                      "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/1280x720/NRpzIavCR5W-jWFh.mp4?tag=12"
+                    }
+                  ]
+                },
+                "media_results": {
+                  "result": {
+                    "media_key": "7_9916110000000000001"
+                  }
+                }
+              }
+            ]
+          },
+          "favorite_count": 296,
+          "favorited": false,
+          "full_text": "Sulphur-crested Cockatoo enjoying the warm Brisbane breeze...   \n@fred_od_photo #birds #birdwatching #birding #WildOz #birdphotography #birdsofaustralia #cockatoo https://t.co/RoMxHhAo9X",
+          "is_quote_status": false,
+          "lang": "en",
+          "possibly_sensitive": false,
+          "possibly_sensitive_editable": true,
+          "quote_count": 1,
+          "reply_count": 2,
+          "retweet_count": 68,
+          "retweeted": false,
+          "user_id_str": "974067190386147329",
+          "id_str": "991610"
+        }
+      }
+    }
+  }
+}

--- a/test/mocks/TweetResultsByIds/991610.json
+++ b/test/mocks/TweetResultsByIds/991610.json
@@ -1,0 +1,510 @@
+{
+  "data": {
+    "tweet_results": [
+      {
+        "result": {
+          "__typename": "Tweet",
+          "rest_id": "991610",
+          "core": {
+            "user_results": {
+              "result": {
+                "__typename": "User",
+                "id": "VXNlcjo5NzQwNjcxOTAzODYxNDczMjk=",
+                "rest_id": "974067190386147329",
+                "affiliates_highlighted_label": {},
+                "parody_commentary_fan_label": "None",
+                "is_blue_verified": false,
+                "profile_image_shape": "Circle",
+                "legacy": {
+                  "created_at": "Wed Mar 14 23:38:10 +0000 2018",
+                  "default_profile": false,
+                  "default_profile_image": false,
+                  "description": "Lover of this land from desert to sea. \nAmateur wildlife photographer, mostly native birdlife. \nAll photographs posted are my original images except reposts.",
+                  "entities": {
+                    "description": {
+                      "urls": []
+                    },
+                    "url": {
+                      "urls": [
+                        {
+                          "display_url": "instagram.com/divine_dropbea…",
+                          "expanded_url": "https://www.instagram.com/divine_dropbear/",
+                          "url": "https://t.co/N0ForImxXd",
+                          "indices": [
+                            0,
+                            23
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  "fast_followers_count": 0,
+                  "favourites_count": 25601,
+                  "followers_count": 2516,
+                  "friends_count": 1508,
+                  "has_custom_timelines": false,
+                  "is_translator": false,
+                  "listed_count": 32,
+                  "location": "@divinedropbear.bsky.social ",
+                  "media_count": 1248,
+                  "name": "Tranquility Found",
+                  "normal_followers_count": 2516,
+                  "pinned_tweet_ids_str": [],
+                  "possibly_sensitive": false,
+                  "profile_banner_url": "https://pbs.twimg.com/profile_banners/974067190386147329/1533093346",
+                  "profile_image_url_https": "https://pbs.twimg.com/profile_images/1871316427581583360/AY58qda4_normal.jpg",
+                  "profile_interstitial_type": "",
+                  "screen_name": "DivineDropbear",
+                  "statuses_count": 11954,
+                  "translator_type": "none",
+                  "url": "https://t.co/N0ForImxXd",
+                  "verified": false,
+                  "withheld_in_countries": []
+                },
+                "tipjar_settings": {
+                  "is_enabled": false,
+                  "bandcamp_handle": "",
+                  "bitcoin_handle": "",
+                  "cash_app_handle": "",
+                  "ethereum_handle": "",
+                  "gofundme_handle": "",
+                  "patreon_handle": "",
+                  "pay_pal_handle": "",
+                  "venmo_handle": ""
+                }
+              }
+            }
+          },
+          "unmention_data": {},
+          "edit_control": {
+            "edit_tweet_ids": [
+              "991610"
+            ],
+            "editable_until_msecs": "1727816358000",
+            "is_edit_eligible": true,
+            "edits_remaining": "5"
+          },
+          "is_translatable": false,
+          "views": {
+            "count": "4186",
+            "state": "EnabledWithCount"
+          },
+          "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+          "grok_analysis_button": true,
+          "legacy": {
+            "bookmark_count": 7,
+            "bookmarked": false,
+            "created_at": "Tue Oct 01 19:59:18 +0000 2024",
+            "conversation_id_str": "991610",
+            "display_text_range": [
+              0,
+              162
+            ],
+            "entities": {
+              "hashtags": [
+                {
+                  "indices": [
+                    80,
+                    86
+                  ],
+                  "text": "birds"
+                },
+                {
+                  "indices": [
+                    87,
+                    100
+                  ],
+                  "text": "birdwatching"
+                },
+                {
+                  "indices": [
+                    101,
+                    109
+                  ],
+                  "text": "birding"
+                },
+                {
+                  "indices": [
+                    110,
+                    117
+                  ],
+                  "text": "WildOz"
+                },
+                {
+                  "indices": [
+                    118,
+                    134
+                  ],
+                  "text": "birdphotography"
+                },
+                {
+                  "indices": [
+                    135,
+                    152
+                  ],
+                  "text": "birdsofaustralia"
+                },
+                {
+                  "indices": [
+                    153,
+                    162
+                  ],
+                  "text": "cockatoo"
+                }
+              ],
+              "media": [
+                {
+                  "display_url": "pic.x.com/RoMxHhAo9X",
+                  "expanded_url": "https://example.invalid/DivineDropbear/status/991610/video/1",
+                  "id_str": "1841204388993646595",
+                  "indices": [
+                    163,
+                    186
+                  ],
+                  "media_key": "7_1841204388993646595",
+                  "media_url_https": "https://pbs.twimg.com/ext_tw_video_thumb/1841204388993646595/pu/img/KKN8tSQm60z2FmtE.jpg",
+                  "type": "video",
+                  "url": "https://t.co/RoMxHhAo9X",
+                  "additional_media_info": {
+                    "monetizable": false
+                  },
+                  "ext_media_availability": {
+                    "status": "Available"
+                  },
+                  "sizes": {
+                    "large": {
+                      "h": 1080,
+                      "w": 1920,
+                      "resize": "fit"
+                    },
+                    "medium": {
+                      "h": 675,
+                      "w": 1200,
+                      "resize": "fit"
+                    },
+                    "small": {
+                      "h": 383,
+                      "w": 680,
+                      "resize": "fit"
+                    },
+                    "thumb": {
+                      "h": 150,
+                      "w": 150,
+                      "resize": "crop"
+                    }
+                  },
+                  "original_info": {
+                    "height": 1080,
+                    "width": 1920,
+                    "focus_rects": []
+                  },
+                  "video_info": {
+                    "aspect_ratio": [
+                      16,
+                      9
+                    ],
+                    "duration_millis": 29626,
+                    "variants": [
+                      {
+                        "content_type": "application/x-mpegURL",
+                        "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/pl/-kd3cWye2HXbiTju.m3u8?tag=12&v=cfc"
+                      },
+                      {
+                        "bitrate": 256000,
+                        "content_type": "video/mp4",
+                        "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/480x270/vxKqarkYhJW80NBu.mp4?tag=12"
+                      },
+                      {
+                        "bitrate": 832000,
+                        "content_type": "video/mp4",
+                        "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/640x360/gap6eNvJGCbYTOWH.mp4?tag=12"
+                      },
+                      {
+                        "bitrate": 2176000,
+                        "content_type": "video/mp4",
+                        "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/1280x720/NRpzIavCR5W-jWFh.mp4?tag=12"
+                      }
+                    ]
+                  },
+                  "media_results": {
+                    "result": {
+                      "media_key": "7_1841204388993646595"
+                    }
+                  }
+                },
+                {
+                  "display_url": "pic.x.com/SecondVideo",
+                  "expanded_url": "https://example.invalid/DivineDropbear/status/991610/video/1",
+                  "id_str": "9916110000000000001",
+                  "indices": [
+                    163,
+                    186
+                  ],
+                  "media_key": "7_9916110000000000001",
+                  "media_url_https": "https://pbs.twimg.com/ext_tw_video_thumb/1841204388993646595/pu/img/KKN8tSQm60z2FmtE.jpg",
+                  "type": "video",
+                  "url": "https://t.co/SecondVideo",
+                  "additional_media_info": {
+                    "monetizable": false
+                  },
+                  "ext_media_availability": {
+                    "status": "Available"
+                  },
+                  "sizes": {
+                    "large": {
+                      "h": 1080,
+                      "w": 1920,
+                      "resize": "fit"
+                    },
+                    "medium": {
+                      "h": 675,
+                      "w": 1200,
+                      "resize": "fit"
+                    },
+                    "small": {
+                      "h": 383,
+                      "w": 680,
+                      "resize": "fit"
+                    },
+                    "thumb": {
+                      "h": 150,
+                      "w": 150,
+                      "resize": "crop"
+                    }
+                  },
+                  "original_info": {
+                    "height": 1080,
+                    "width": 1920,
+                    "focus_rects": []
+                  },
+                  "video_info": {
+                    "aspect_ratio": [
+                      16,
+                      9
+                    ],
+                    "duration_millis": 29626,
+                    "variants": [
+                      {
+                        "content_type": "application/x-mpegURL",
+                        "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/pl/-kd3cWye2HXbiTju.m3u8?tag=12&v=cfc"
+                      },
+                      {
+                        "bitrate": 256000,
+                        "content_type": "video/mp4",
+                        "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/480x270/vxKqarkYhJW80NBu.mp4?tag=12"
+                      },
+                      {
+                        "bitrate": 832000,
+                        "content_type": "video/mp4",
+                        "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/640x360/gap6eNvJGCbYTOWH.mp4?tag=12"
+                      },
+                      {
+                        "bitrate": 2176000,
+                        "content_type": "video/mp4",
+                        "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/1280x720/NRpzIavCR5W-jWFh.mp4?tag=12"
+                      }
+                    ]
+                  },
+                  "media_results": {
+                    "result": {
+                      "media_key": "7_9916110000000000001"
+                    }
+                  }
+                }
+              ],
+              "symbols": [],
+              "timestamps": [],
+              "urls": [],
+              "user_mentions": [
+                {
+                  "id_str": "490232734",
+                  "name": "Fred O'Donnell",
+                  "screen_name": "fred_od_photo",
+                  "indices": [
+                    65,
+                    79
+                  ]
+                }
+              ]
+            },
+            "extended_entities": {
+              "media": [
+                {
+                  "display_url": "pic.x.com/RoMxHhAo9X",
+                  "expanded_url": "https://example.invalid/DivineDropbear/status/991610/video/1",
+                  "id_str": "1841204388993646595",
+                  "indices": [
+                    163,
+                    186
+                  ],
+                  "media_key": "7_1841204388993646595",
+                  "media_url_https": "https://pbs.twimg.com/ext_tw_video_thumb/1841204388993646595/pu/img/KKN8tSQm60z2FmtE.jpg",
+                  "type": "video",
+                  "url": "https://t.co/RoMxHhAo9X",
+                  "additional_media_info": {
+                    "monetizable": false
+                  },
+                  "ext_media_availability": {
+                    "status": "Available"
+                  },
+                  "sizes": {
+                    "large": {
+                      "h": 1080,
+                      "w": 1920,
+                      "resize": "fit"
+                    },
+                    "medium": {
+                      "h": 675,
+                      "w": 1200,
+                      "resize": "fit"
+                    },
+                    "small": {
+                      "h": 383,
+                      "w": 680,
+                      "resize": "fit"
+                    },
+                    "thumb": {
+                      "h": 150,
+                      "w": 150,
+                      "resize": "crop"
+                    }
+                  },
+                  "original_info": {
+                    "height": 1080,
+                    "width": 1920,
+                    "focus_rects": []
+                  },
+                  "video_info": {
+                    "aspect_ratio": [
+                      16,
+                      9
+                    ],
+                    "duration_millis": 29626,
+                    "variants": [
+                      {
+                        "content_type": "application/x-mpegURL",
+                        "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/pl/-kd3cWye2HXbiTju.m3u8?tag=12&v=cfc"
+                      },
+                      {
+                        "bitrate": 256000,
+                        "content_type": "video/mp4",
+                        "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/480x270/vxKqarkYhJW80NBu.mp4?tag=12"
+                      },
+                      {
+                        "bitrate": 832000,
+                        "content_type": "video/mp4",
+                        "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/640x360/gap6eNvJGCbYTOWH.mp4?tag=12"
+                      },
+                      {
+                        "bitrate": 2176000,
+                        "content_type": "video/mp4",
+                        "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/1280x720/NRpzIavCR5W-jWFh.mp4?tag=12"
+                      }
+                    ]
+                  },
+                  "media_results": {
+                    "result": {
+                      "media_key": "7_1841204388993646595"
+                    }
+                  }
+                },
+                {
+                  "display_url": "pic.x.com/SecondVideo",
+                  "expanded_url": "https://example.invalid/DivineDropbear/status/991610/video/1",
+                  "id_str": "9916110000000000001",
+                  "indices": [
+                    163,
+                    186
+                  ],
+                  "media_key": "7_9916110000000000001",
+                  "media_url_https": "https://pbs.twimg.com/ext_tw_video_thumb/1841204388993646595/pu/img/KKN8tSQm60z2FmtE.jpg",
+                  "type": "video",
+                  "url": "https://t.co/SecondVideo",
+                  "additional_media_info": {
+                    "monetizable": false
+                  },
+                  "ext_media_availability": {
+                    "status": "Available"
+                  },
+                  "sizes": {
+                    "large": {
+                      "h": 1080,
+                      "w": 1920,
+                      "resize": "fit"
+                    },
+                    "medium": {
+                      "h": 675,
+                      "w": 1200,
+                      "resize": "fit"
+                    },
+                    "small": {
+                      "h": 383,
+                      "w": 680,
+                      "resize": "fit"
+                    },
+                    "thumb": {
+                      "h": 150,
+                      "w": 150,
+                      "resize": "crop"
+                    }
+                  },
+                  "original_info": {
+                    "height": 1080,
+                    "width": 1920,
+                    "focus_rects": []
+                  },
+                  "video_info": {
+                    "aspect_ratio": [
+                      16,
+                      9
+                    ],
+                    "duration_millis": 29626,
+                    "variants": [
+                      {
+                        "content_type": "application/x-mpegURL",
+                        "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/pl/-kd3cWye2HXbiTju.m3u8?tag=12&v=cfc"
+                      },
+                      {
+                        "bitrate": 256000,
+                        "content_type": "video/mp4",
+                        "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/480x270/vxKqarkYhJW80NBu.mp4?tag=12"
+                      },
+                      {
+                        "bitrate": 832000,
+                        "content_type": "video/mp4",
+                        "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/640x360/gap6eNvJGCbYTOWH.mp4?tag=12"
+                      },
+                      {
+                        "bitrate": 2176000,
+                        "content_type": "video/mp4",
+                        "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/1280x720/NRpzIavCR5W-jWFh.mp4?tag=12"
+                      }
+                    ]
+                  },
+                  "media_results": {
+                    "result": {
+                      "media_key": "7_9916110000000000001"
+                    }
+                  }
+                }
+              ]
+            },
+            "favorite_count": 296,
+            "favorited": false,
+            "full_text": "Sulphur-crested Cockatoo enjoying the warm Brisbane breeze...   \n@fred_od_photo #birds #birdwatching #birding #WildOz #birdphotography #birdsofaustralia #cockatoo https://t.co/RoMxHhAo9X",
+            "is_quote_status": false,
+            "lang": "en",
+            "possibly_sensitive": false,
+            "possibly_sensitive_editable": true,
+            "quote_count": 1,
+            "reply_count": 2,
+            "retweet_count": 68,
+            "retweeted": false,
+            "user_id_str": "974067190386147329",
+            "id_str": "991610"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/mocks/TweetResultsByRestIds/991610.json
+++ b/test/mocks/TweetResultsByRestIds/991610.json
@@ -1,0 +1,510 @@
+{
+  "data": {
+    "tweetResult": [
+      {
+        "result": {
+          "__typename": "Tweet",
+          "rest_id": "991610",
+          "core": {
+            "user_results": {
+              "result": {
+                "__typename": "User",
+                "id": "VXNlcjo5NzQwNjcxOTAzODYxNDczMjk=",
+                "rest_id": "974067190386147329",
+                "affiliates_highlighted_label": {},
+                "parody_commentary_fan_label": "None",
+                "is_blue_verified": false,
+                "profile_image_shape": "Circle",
+                "legacy": {
+                  "created_at": "Wed Mar 14 23:38:10 +0000 2018",
+                  "default_profile": false,
+                  "default_profile_image": false,
+                  "description": "Lover of this land from desert to sea. \nAmateur wildlife photographer, mostly native birdlife. \nAll photographs posted are my original images except reposts.",
+                  "entities": {
+                    "description": {
+                      "urls": []
+                    },
+                    "url": {
+                      "urls": [
+                        {
+                          "display_url": "instagram.com/divine_dropbea…",
+                          "expanded_url": "https://www.instagram.com/divine_dropbear/",
+                          "url": "https://t.co/N0ForImxXd",
+                          "indices": [
+                            0,
+                            23
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  "fast_followers_count": 0,
+                  "favourites_count": 25601,
+                  "followers_count": 2516,
+                  "friends_count": 1508,
+                  "has_custom_timelines": false,
+                  "is_translator": false,
+                  "listed_count": 32,
+                  "location": "@divinedropbear.bsky.social ",
+                  "media_count": 1248,
+                  "name": "Tranquility Found",
+                  "normal_followers_count": 2516,
+                  "pinned_tweet_ids_str": [],
+                  "possibly_sensitive": false,
+                  "profile_banner_url": "https://pbs.twimg.com/profile_banners/974067190386147329/1533093346",
+                  "profile_image_url_https": "https://pbs.twimg.com/profile_images/1871316427581583360/AY58qda4_normal.jpg",
+                  "profile_interstitial_type": "",
+                  "screen_name": "DivineDropbear",
+                  "statuses_count": 11954,
+                  "translator_type": "none",
+                  "url": "https://t.co/N0ForImxXd",
+                  "verified": false,
+                  "withheld_in_countries": []
+                },
+                "tipjar_settings": {
+                  "is_enabled": false,
+                  "bandcamp_handle": "",
+                  "bitcoin_handle": "",
+                  "cash_app_handle": "",
+                  "ethereum_handle": "",
+                  "gofundme_handle": "",
+                  "patreon_handle": "",
+                  "pay_pal_handle": "",
+                  "venmo_handle": ""
+                }
+              }
+            }
+          },
+          "unmention_data": {},
+          "edit_control": {
+            "edit_tweet_ids": [
+              "991610"
+            ],
+            "editable_until_msecs": "1727816358000",
+            "is_edit_eligible": true,
+            "edits_remaining": "5"
+          },
+          "is_translatable": false,
+          "views": {
+            "count": "4186",
+            "state": "EnabledWithCount"
+          },
+          "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+          "grok_analysis_button": true,
+          "legacy": {
+            "bookmark_count": 7,
+            "bookmarked": false,
+            "created_at": "Tue Oct 01 19:59:18 +0000 2024",
+            "conversation_id_str": "991610",
+            "display_text_range": [
+              0,
+              162
+            ],
+            "entities": {
+              "hashtags": [
+                {
+                  "indices": [
+                    80,
+                    86
+                  ],
+                  "text": "birds"
+                },
+                {
+                  "indices": [
+                    87,
+                    100
+                  ],
+                  "text": "birdwatching"
+                },
+                {
+                  "indices": [
+                    101,
+                    109
+                  ],
+                  "text": "birding"
+                },
+                {
+                  "indices": [
+                    110,
+                    117
+                  ],
+                  "text": "WildOz"
+                },
+                {
+                  "indices": [
+                    118,
+                    134
+                  ],
+                  "text": "birdphotography"
+                },
+                {
+                  "indices": [
+                    135,
+                    152
+                  ],
+                  "text": "birdsofaustralia"
+                },
+                {
+                  "indices": [
+                    153,
+                    162
+                  ],
+                  "text": "cockatoo"
+                }
+              ],
+              "media": [
+                {
+                  "display_url": "pic.x.com/RoMxHhAo9X",
+                  "expanded_url": "https://example.invalid/DivineDropbear/status/991610/video/1",
+                  "id_str": "1841204388993646595",
+                  "indices": [
+                    163,
+                    186
+                  ],
+                  "media_key": "7_1841204388993646595",
+                  "media_url_https": "https://pbs.twimg.com/ext_tw_video_thumb/1841204388993646595/pu/img/KKN8tSQm60z2FmtE.jpg",
+                  "type": "video",
+                  "url": "https://t.co/RoMxHhAo9X",
+                  "additional_media_info": {
+                    "monetizable": false
+                  },
+                  "ext_media_availability": {
+                    "status": "Available"
+                  },
+                  "sizes": {
+                    "large": {
+                      "h": 1080,
+                      "w": 1920,
+                      "resize": "fit"
+                    },
+                    "medium": {
+                      "h": 675,
+                      "w": 1200,
+                      "resize": "fit"
+                    },
+                    "small": {
+                      "h": 383,
+                      "w": 680,
+                      "resize": "fit"
+                    },
+                    "thumb": {
+                      "h": 150,
+                      "w": 150,
+                      "resize": "crop"
+                    }
+                  },
+                  "original_info": {
+                    "height": 1080,
+                    "width": 1920,
+                    "focus_rects": []
+                  },
+                  "video_info": {
+                    "aspect_ratio": [
+                      16,
+                      9
+                    ],
+                    "duration_millis": 29626,
+                    "variants": [
+                      {
+                        "content_type": "application/x-mpegURL",
+                        "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/pl/-kd3cWye2HXbiTju.m3u8?tag=12&v=cfc"
+                      },
+                      {
+                        "bitrate": 256000,
+                        "content_type": "video/mp4",
+                        "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/480x270/vxKqarkYhJW80NBu.mp4?tag=12"
+                      },
+                      {
+                        "bitrate": 832000,
+                        "content_type": "video/mp4",
+                        "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/640x360/gap6eNvJGCbYTOWH.mp4?tag=12"
+                      },
+                      {
+                        "bitrate": 2176000,
+                        "content_type": "video/mp4",
+                        "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/1280x720/NRpzIavCR5W-jWFh.mp4?tag=12"
+                      }
+                    ]
+                  },
+                  "media_results": {
+                    "result": {
+                      "media_key": "7_1841204388993646595"
+                    }
+                  }
+                },
+                {
+                  "display_url": "pic.x.com/SecondVideo",
+                  "expanded_url": "https://example.invalid/DivineDropbear/status/991610/video/1",
+                  "id_str": "9916110000000000001",
+                  "indices": [
+                    163,
+                    186
+                  ],
+                  "media_key": "7_9916110000000000001",
+                  "media_url_https": "https://pbs.twimg.com/ext_tw_video_thumb/1841204388993646595/pu/img/KKN8tSQm60z2FmtE.jpg",
+                  "type": "video",
+                  "url": "https://t.co/SecondVideo",
+                  "additional_media_info": {
+                    "monetizable": false
+                  },
+                  "ext_media_availability": {
+                    "status": "Available"
+                  },
+                  "sizes": {
+                    "large": {
+                      "h": 1080,
+                      "w": 1920,
+                      "resize": "fit"
+                    },
+                    "medium": {
+                      "h": 675,
+                      "w": 1200,
+                      "resize": "fit"
+                    },
+                    "small": {
+                      "h": 383,
+                      "w": 680,
+                      "resize": "fit"
+                    },
+                    "thumb": {
+                      "h": 150,
+                      "w": 150,
+                      "resize": "crop"
+                    }
+                  },
+                  "original_info": {
+                    "height": 1080,
+                    "width": 1920,
+                    "focus_rects": []
+                  },
+                  "video_info": {
+                    "aspect_ratio": [
+                      16,
+                      9
+                    ],
+                    "duration_millis": 29626,
+                    "variants": [
+                      {
+                        "content_type": "application/x-mpegURL",
+                        "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/pl/-kd3cWye2HXbiTju.m3u8?tag=12&v=cfc"
+                      },
+                      {
+                        "bitrate": 256000,
+                        "content_type": "video/mp4",
+                        "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/480x270/vxKqarkYhJW80NBu.mp4?tag=12"
+                      },
+                      {
+                        "bitrate": 832000,
+                        "content_type": "video/mp4",
+                        "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/640x360/gap6eNvJGCbYTOWH.mp4?tag=12"
+                      },
+                      {
+                        "bitrate": 2176000,
+                        "content_type": "video/mp4",
+                        "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/1280x720/NRpzIavCR5W-jWFh.mp4?tag=12"
+                      }
+                    ]
+                  },
+                  "media_results": {
+                    "result": {
+                      "media_key": "7_9916110000000000001"
+                    }
+                  }
+                }
+              ],
+              "symbols": [],
+              "timestamps": [],
+              "urls": [],
+              "user_mentions": [
+                {
+                  "id_str": "490232734",
+                  "name": "Fred O'Donnell",
+                  "screen_name": "fred_od_photo",
+                  "indices": [
+                    65,
+                    79
+                  ]
+                }
+              ]
+            },
+            "extended_entities": {
+              "media": [
+                {
+                  "display_url": "pic.x.com/RoMxHhAo9X",
+                  "expanded_url": "https://example.invalid/DivineDropbear/status/991610/video/1",
+                  "id_str": "1841204388993646595",
+                  "indices": [
+                    163,
+                    186
+                  ],
+                  "media_key": "7_1841204388993646595",
+                  "media_url_https": "https://pbs.twimg.com/ext_tw_video_thumb/1841204388993646595/pu/img/KKN8tSQm60z2FmtE.jpg",
+                  "type": "video",
+                  "url": "https://t.co/RoMxHhAo9X",
+                  "additional_media_info": {
+                    "monetizable": false
+                  },
+                  "ext_media_availability": {
+                    "status": "Available"
+                  },
+                  "sizes": {
+                    "large": {
+                      "h": 1080,
+                      "w": 1920,
+                      "resize": "fit"
+                    },
+                    "medium": {
+                      "h": 675,
+                      "w": 1200,
+                      "resize": "fit"
+                    },
+                    "small": {
+                      "h": 383,
+                      "w": 680,
+                      "resize": "fit"
+                    },
+                    "thumb": {
+                      "h": 150,
+                      "w": 150,
+                      "resize": "crop"
+                    }
+                  },
+                  "original_info": {
+                    "height": 1080,
+                    "width": 1920,
+                    "focus_rects": []
+                  },
+                  "video_info": {
+                    "aspect_ratio": [
+                      16,
+                      9
+                    ],
+                    "duration_millis": 29626,
+                    "variants": [
+                      {
+                        "content_type": "application/x-mpegURL",
+                        "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/pl/-kd3cWye2HXbiTju.m3u8?tag=12&v=cfc"
+                      },
+                      {
+                        "bitrate": 256000,
+                        "content_type": "video/mp4",
+                        "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/480x270/vxKqarkYhJW80NBu.mp4?tag=12"
+                      },
+                      {
+                        "bitrate": 832000,
+                        "content_type": "video/mp4",
+                        "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/640x360/gap6eNvJGCbYTOWH.mp4?tag=12"
+                      },
+                      {
+                        "bitrate": 2176000,
+                        "content_type": "video/mp4",
+                        "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/1280x720/NRpzIavCR5W-jWFh.mp4?tag=12"
+                      }
+                    ]
+                  },
+                  "media_results": {
+                    "result": {
+                      "media_key": "7_1841204388993646595"
+                    }
+                  }
+                },
+                {
+                  "display_url": "pic.x.com/SecondVideo",
+                  "expanded_url": "https://example.invalid/DivineDropbear/status/991610/video/1",
+                  "id_str": "9916110000000000001",
+                  "indices": [
+                    163,
+                    186
+                  ],
+                  "media_key": "7_9916110000000000001",
+                  "media_url_https": "https://pbs.twimg.com/ext_tw_video_thumb/1841204388993646595/pu/img/KKN8tSQm60z2FmtE.jpg",
+                  "type": "video",
+                  "url": "https://t.co/SecondVideo",
+                  "additional_media_info": {
+                    "monetizable": false
+                  },
+                  "ext_media_availability": {
+                    "status": "Available"
+                  },
+                  "sizes": {
+                    "large": {
+                      "h": 1080,
+                      "w": 1920,
+                      "resize": "fit"
+                    },
+                    "medium": {
+                      "h": 675,
+                      "w": 1200,
+                      "resize": "fit"
+                    },
+                    "small": {
+                      "h": 383,
+                      "w": 680,
+                      "resize": "fit"
+                    },
+                    "thumb": {
+                      "h": 150,
+                      "w": 150,
+                      "resize": "crop"
+                    }
+                  },
+                  "original_info": {
+                    "height": 1080,
+                    "width": 1920,
+                    "focus_rects": []
+                  },
+                  "video_info": {
+                    "aspect_ratio": [
+                      16,
+                      9
+                    ],
+                    "duration_millis": 29626,
+                    "variants": [
+                      {
+                        "content_type": "application/x-mpegURL",
+                        "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/pl/-kd3cWye2HXbiTju.m3u8?tag=12&v=cfc"
+                      },
+                      {
+                        "bitrate": 256000,
+                        "content_type": "video/mp4",
+                        "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/480x270/vxKqarkYhJW80NBu.mp4?tag=12"
+                      },
+                      {
+                        "bitrate": 832000,
+                        "content_type": "video/mp4",
+                        "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/640x360/gap6eNvJGCbYTOWH.mp4?tag=12"
+                      },
+                      {
+                        "bitrate": 2176000,
+                        "content_type": "video/mp4",
+                        "url": "https://video.twimg.com/ext_tw_video/1841204388993646595/pu/vid/avc1/1280x720/NRpzIavCR5W-jWFh.mp4?tag=12"
+                      }
+                    ]
+                  },
+                  "media_results": {
+                    "result": {
+                      "media_key": "7_9916110000000000001"
+                    }
+                  }
+                }
+              ]
+            },
+            "favorite_count": 296,
+            "favorited": false,
+            "full_text": "Sulphur-crested Cockatoo enjoying the warm Brisbane breeze...   \n@fred_od_photo #birds #birdwatching #birding #WildOz #birdphotography #birdsofaustralia #cockatoo https://t.co/RoMxHhAo9X",
+            "is_quote_status": false,
+            "lang": "en",
+            "possibly_sensitive": false,
+            "possibly_sensitive_editable": true,
+            "quote_count": 1,
+            "reply_count": 2,
+            "retweet_count": 68,
+            "retweeted": false,
+            "user_id_str": "974067190386147329",
+            "id_str": "991610"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/telegram.instantview.test.ts
+++ b/test/telegram.instantview.test.ts
@@ -1,0 +1,70 @@
+import { test, expect } from 'vitest';
+import { app } from '../src/worker';
+import { botHeaders } from './helpers/data';
+import harness from './helpers/harness';
+
+const telegramHeaders = { 'User-Agent': 'TelegramBot (like TwitterBot)' };
+
+const fetchEmbed = async (url: string, headers: Record<string, string>) => {
+  const result = await app.request(
+    new Request(url, { method: 'GET', headers }),
+    undefined,
+    harness
+  );
+  expect(result.status).toEqual(200);
+  return result.text();
+};
+
+const isInstantViewHtml = (html: string) =>
+  html.includes('al:android:app_name" content="Medium"') &&
+  html.includes('article:published_time') &&
+  html.includes('<!-- Telegram Instant View -->');
+
+test('Telegram Instant View is enabled for posts with multiple videos', async () => {
+  const html = await fetchEmbed(
+    'https://fxtwitter.com/DivineDropbear/status/991610',
+    telegramHeaders
+  );
+
+  expect(isInstantViewHtml(html)).toBe(true);
+  expect(html.match(/<video /g)?.length).toBeGreaterThanOrEqual(2);
+  expect(html).toContain('og:site_name" content="FxTwitter - Video 1 / 2"');
+});
+
+test('Telegram Instant View is not enabled for a single video', async () => {
+  const html = await fetchEmbed(
+    'https://fxtwitter.com/DivineDropbear/status/1841206275088290279',
+    telegramHeaders
+  );
+
+  expect(isInstantViewHtml(html)).toBe(false);
+  expect(html).not.toContain('<video ');
+  expect(html).toContain('twitter:card" content="player"');
+});
+
+test('Discord does not receive Instant View for multi-video posts', async () => {
+  const html = await fetchEmbed('https://fxtwitter.com/DivineDropbear/status/991610', botHeaders);
+
+  expect(isInstantViewHtml(html)).toBe(false);
+  expect(html).not.toContain('<video ');
+});
+
+test('Telegram Instant View remains enabled for multi-photo mosaic posts', async () => {
+  const html = await fetchEmbed(
+    'https://fxtwitter.com/SpaceX/status/1848831595014459513',
+    telegramHeaders
+  );
+
+  expect(isInstantViewHtml(html)).toBe(true);
+  expect(html.match(/<img /g)?.length).toBeGreaterThanOrEqual(3);
+});
+
+test('i. prefix still forces Instant View for a single video', async () => {
+  const html = await fetchEmbed(
+    'https://i.fxtwitter.com/DivineDropbear/status/1841206275088290279',
+    telegramHeaders
+  );
+
+  expect(isInstantViewHtml(html)).toBe(true);
+  expect(html.match(/<video /g)?.length).toBeGreaterThanOrEqual(1);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Telegram Instant View was **not** being generated for video-only posts, even when a tweet contained several videos. That is an FxEmbed gap, not a Telegram Instant View outage.

Production HTML for `https://fxtwitter.com/HardwareSteam/status/2090046986900717837` (4 videos) had:

- `og:site_name` = `FxTwitter - Video 1 / 4` (the single-video preview fallback)
- empty body
- no Medium Instant View meta tags

The same post on `i.fxtwitter.com` already rendered all four `<video>` tags. Instant View markup works; we just never opted video-only posts into it.

Photos already force IV (`status.media?.photos?.[0]` / mosaic). This change also enables IV when `videos.length > 1`, so Telegram can still play the first clip in the card and Instant View lists the rest.

Single-video posts stay on the inline player (no IV).

## Testing

- `npm test -- test/telegram.instantview.test.ts` — 5/5 passed
  - multi-video Telegram UA → Instant View HTML + ≥2 `<video>` tags
  - single-video Telegram UA → no Instant View
  - Discord UA → no Instant View
  - mosaic photos still get Instant View
  - `i.` prefix still forces Instant View for a single video
- `npm test -- test/activity.test.ts test/bot.test.ts` — 10/10 passed
- eslint on changed files — clean

After deploy, Telegram still has to recrawl the URL (or use `@webpagebot`) before the Instant View button appears on an already-cached preview.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01c30-ab2b-74d0-b945-9e86fe2eabb1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01c30-ab2b-74d0-b945-9e86fe2eabb1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Telegram Instant View now includes all videos in posts containing multiple videos.

- **Bug Fixes**
  - Improved handling of multi-video posts in Instant View presentations.

- **Tests**
  - Added coverage for multi-video posts, single-video behavior, photo mosaics, prefix overrides, and excluded integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->