### PR TITLE
fix: make mosaic url/width/height optional in OpenAPI

### DIFF
--- a/docs/specs/fxbluesky-openapi.json
+++ b/docs/specs/fxbluesky-openapi.json
@@ -440,7 +440,7 @@
                           "required": ["webp", "jpeg"]
                         }
                       },
-                      "required": ["type", "url", "width", "height", "formats"]
+                      "required": ["type", "formats"]
                     },
                     {
                       "type": "object",
@@ -504,7 +504,7 @@
                     "required": ["webp", "jpeg"]
                   }
                 },
-                "required": ["type", "url", "width", "height", "formats"]
+                "required": ["type", "formats"]
               },
               "broadcast": {
                 "type": "object",
@@ -2630,7 +2630,7 @@
                           "required": ["webp", "jpeg"]
                         }
                       },
-                      "required": ["type", "url", "width", "height", "formats"]
+                      "required": ["type", "formats"]
                     },
                     {
                       "type": "object",
@@ -2694,7 +2694,7 @@
                     "required": ["webp", "jpeg"]
                   }
                 },
-                "required": ["type", "url", "width", "height", "formats"]
+                "required": ["type", "formats"]
               },
               "broadcast": {
                 "type": "object",

--- a/docs/specs/fxtwitter-openapi.json
+++ b/docs/specs/fxtwitter-openapi.json
@@ -440,7 +440,7 @@
                           "required": ["webp", "jpeg"]
                         }
                       },
-                      "required": ["type", "url", "width", "height", "formats"]
+                      "required": ["type", "formats"]
                     },
                     {
                       "type": "object",
@@ -504,7 +504,7 @@
                     "required": ["webp", "jpeg"]
                   }
                 },
-                "required": ["type", "url", "width", "height", "formats"]
+                "required": ["type", "formats"]
               },
               "broadcast": {
                 "type": "object",

--- a/packages/atmosphere/src/helpers/mosaic.ts
+++ b/packages/atmosphere/src/helpers/mosaic.ts
@@ -77,5 +77,5 @@ export const handleMosaic = async (
       jpeg: `${baseUrl}jpeg/${id}${path}`,
       webp: `${baseUrl}webp/${id}${path}`
     }
-  } as APIMosaicPhoto;
+  };
 };

--- a/packages/atmosphere/src/types/api-schemas.ts
+++ b/packages/atmosphere/src/types/api-schemas.ts
@@ -198,9 +198,10 @@ export const APIMosaicPhotoSchema = z.object({
   id: z.string().optional(),
   format: z.string().optional(),
   type: z.literal('mosaic_photo'),
-  url: z.string(),
-  width: z.number(),
-  height: z.number(),
+  // Runtime mosaic responses only guarantee type + formats; url/width/height are optional.
+  url: z.string().optional(),
+  width: z.number().optional(),
+  height: z.number().optional(),
   formats: z.object({
     webp: z.string(),
     jpeg: z.string()


### PR DESCRIPTION
Runtime `media.mosaic` only returns `type` and `formats`; this makes `url`/`width`/`height` optional in the Zod schema and OpenAPI snapshots so clients validating against the schema stop rejecting mosaic posts.

Fixes #2365

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support for mosaic media that does not include a URL, width, or height.
  * Mosaic media now requires only its type and available formats, providing more flexible API responses.

* **Documentation**
  * Updated the FxTwitter and Bluesky API specifications to reflect the revised mosaic media requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->