### PR TITLE
fix: restore Traditional Chinese translation language codes

### DIFF
--- a/i18n/resources.js
+++ b/i18n/resources.js
@@ -57,5 +57,7 @@ export default {
   'uk': { translation: uk },
   'vi': { translation: vi },
   'zh-CN': { translation: zhCN },
-  'zh-TW': { translation: zhTW }
+  'zh-cn': { translation: zhCN },
+  'zh-TW': { translation: zhTW },
+  'zh-tw': { translation: zhTW }
 };

--- a/packages/atmosphere/src/helpers/language.ts
+++ b/packages/atmosphere/src/helpers/language.ts
@@ -39,12 +39,18 @@ export const isTranslatableLanguageCode = (language: string | null | undefined):
 };
 
 export const normalizeLanguage = (language: string) => {
+  language = language.trim().toLowerCase();
   switch (language) {
     case 'zh':
     case 'cn':
+    case 'zh-hans':
       language = 'zh-cn';
       break;
     case 'tw':
+    case 'hk':
+    case 'zh-hk':
+    case 'zh-mo':
+    case 'zh-hant':
       language = 'zh-tw';
       break;
     case 'jp':
@@ -60,4 +66,31 @@ export const normalizeLanguage = (language: string) => {
       break;
   }
   return language;
+};
+
+/**
+ * Match Grok/X inline translation destination codes to a requested target.
+ * X often reports destination_language as bare `zh` for both Simplified and Traditional;
+ * mapping that through normalizeLanguage alone would force `zh-cn` and reject `/zh-tw`.
+ */
+export const translationDestinationMatches = (
+  destinationLanguage: string | null | undefined,
+  targetLanguage: string
+): boolean => {
+  if (typeof destinationLanguage !== 'string') {
+    return false;
+  }
+  const dest = destinationLanguage.trim().toLowerCase();
+  if (dest.length === 0) {
+    return false;
+  }
+  const target = normalizeLanguage(targetLanguage);
+  if (normalizeLanguage(dest) === target) {
+    return true;
+  }
+  // Bare "zh" from Grok: accept for either Chinese script target (client language header selects script).
+  if (dest === 'zh' && (target === 'zh-cn' || target === 'zh-tw')) {
+    return true;
+  }
+  return false;
 };

--- a/packages/atmosphere/src/providers/twitter/processor.ts
+++ b/packages/atmosphere/src/providers/twitter/processor.ts
@@ -19,7 +19,11 @@ import type {
 import type { FetchResults } from '../../types/fetch-results.js';
 import { isTombstone, tombstoneMessageForReason } from '../../helpers/tombstone.js';
 import { translateStatusGrok } from '../../helpers/translate-grok.js';
-import { normalizeLanguage, isTranslatableLanguageCode } from '../../helpers/language.js';
+import {
+  normalizeLanguage,
+  isTranslatableLanguageCode,
+  translationDestinationMatches
+} from '../../helpers/language.js';
 import { tcoResolver } from './tcoResolver.js';
 import type { TwitterBuildHost } from './build-host.js';
 
@@ -979,14 +983,15 @@ export const buildAPITwitterStatus = async (
   }
 
   /* If a language is specified in API or by user, let's try translating it! */
+  const normalizedTarget =
+    typeof language === 'string' ? normalizeLanguage(language) : '';
   if (
     typeof language === 'string' &&
-    (language.length === 2 || language.length === 5) && // Only translate if the language is a valid ISO 639-1 or ISO 639-5 code
+    (normalizedTarget.length === 2 || normalizedTarget.length === 5) && // ISO 639-1 or regional (e.g. zh-tw)
     isTranslatableLanguageCode(status.legacy?.lang) &&
-    normalizeLanguage(language) !== normalizeLanguage(status.legacy?.lang || '') &&
+    normalizedTarget !== normalizeLanguage(status.legacy?.lang || '') &&
     apiStatus.text.length > 1 // Don't translate if the status text is too short
   ) {
-    const normalizedTarget = normalizeLanguage(language);
     console.log(`Attempting to translate status to ${normalizedTarget}...`);
     let didTranslate = false;
     const inline = status.grok_translated_post_with_availability;
@@ -995,7 +1000,7 @@ export const buildAPITwitterStatus = async (
       inline.data &&
       typeof inline.data.translation === 'string' &&
       inline.data.translation.trim().length > 0 &&
-      normalizeLanguage(inline.data.destination_language) === normalizedTarget
+      translationDestinationMatches(inline.data.destination_language, normalizedTarget)
     ) {
       const srcLang = (inline.data.source_language || apiStatus.lang || 'en').toLowerCase();
       apiStatus.translation = {

--- a/src/helpers/language.ts
+++ b/src/helpers/language.ts
@@ -1,5 +1,6 @@
 export {
   buildLanguageHeaders,
   isTranslatableLanguageCode,
-  normalizeLanguage
+  normalizeLanguage,
+  translationDestinationMatches
 } from '@fxembed/atmosphere/helpers';

--- a/test/language.test.ts
+++ b/test/language.test.ts
@@ -1,7 +1,9 @@
 import { expect, test } from 'vitest';
 import {
   isTranslatableLanguageCode,
-  NON_TRANSLATABLE_LANGUAGE_CODES
+  NON_TRANSLATABLE_LANGUAGE_CODES,
+  normalizeLanguage,
+  translationDestinationMatches
 } from '@fxembed/atmosphere/helpers';
 
 test('NON_TRANSLATABLE_LANGUAGE_CODES includes X pseudo language codes', () => {
@@ -30,4 +32,26 @@ test('isTranslatableLanguageCode rejects pseudo and unknown language codes', () 
   expect(isTranslatableLanguageCode('')).toBe(false);
   expect(isTranslatableLanguageCode(null)).toBe(false);
   expect(isTranslatableLanguageCode(undefined)).toBe(false);
+});
+
+test('normalizeLanguage maps Traditional Chinese aliases to zh-tw', () => {
+  expect(normalizeLanguage('zh-tw')).toBe('zh-tw');
+  expect(normalizeLanguage('zh-TW')).toBe('zh-tw');
+  expect(normalizeLanguage('tw')).toBe('zh-tw');
+  expect(normalizeLanguage('zh-hk')).toBe('zh-tw');
+  expect(normalizeLanguage('hk')).toBe('zh-tw');
+  expect(normalizeLanguage('zh-hant')).toBe('zh-tw');
+  expect(normalizeLanguage('zh')).toBe('zh-cn');
+  expect(normalizeLanguage('zh-cn')).toBe('zh-cn');
+  expect(normalizeLanguage('zh-hans')).toBe('zh-cn');
+});
+
+test('translationDestinationMatches accepts bare zh for Chinese targets', () => {
+  expect(translationDestinationMatches('zh', 'zh-tw')).toBe(true);
+  expect(translationDestinationMatches('zh', 'zh-cn')).toBe(true);
+  expect(translationDestinationMatches('zh-tw', 'zh-tw')).toBe(true);
+  expect(translationDestinationMatches('zh-TW', 'zh-hk')).toBe(true);
+  expect(translationDestinationMatches('zh-cn', 'zh-tw')).toBe(false);
+  expect(translationDestinationMatches('en', 'zh-tw')).toBe(false);
+  expect(translationDestinationMatches(null, 'zh-tw')).toBe(false);
 });


### PR DESCRIPTION
Map `zh-hk`/`zh-hant` to `zh-tw` and treat Grok's bare destination language `zh` as matching Traditional/Simplified targets so `/zh-tw` and `/zh-hk` translations work again.

Fixes #1494

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for Chinese locale variants, including Simplified and Traditional Chinese aliases.
  * Added more reliable matching for Chinese translation destinations.

* **Bug Fixes**
  * Translation validation now handles capitalization, whitespace, and regional language codes consistently.
  * Inline translations are accepted correctly when language variants are equivalent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->