### PR TITLE
Cap FxTwitter /2/search queries at 512 characters

### DIFF
--- a/packages/atmosphere/src/providers/twitter/proxy/errors.ts
+++ b/packages/atmosphere/src/providers/twitter/proxy/errors.ts
@@ -205,6 +205,11 @@ const ERROR_RULES: ErrorRule[] = [
     match: ({ json }) => parseSearchTimelineClientError(json) === 'blocklisted',
     disposition: 'ignore',
     log: 'SearchTimeline blocklisted query (expected client error)'
+  },
+  {
+    match: ({ json }) => parseSearchTimelineClientError(json) === 'query_too_long',
+    disposition: 'ignore',
+    log: 'SearchTimeline query exceeds max length (expected client error)'
   }
 ];
 

--- a/packages/atmosphere/src/providers/twitter/search.ts
+++ b/packages/atmosphere/src/providers/twitter/search.ts
@@ -6,7 +6,9 @@ import { isTombstone } from '../../helpers/tombstone.js';
 import {
   isSearchTimelineClientErrorResponse,
   parseSearchTimelineClientError,
-  searchTimelineClientErrorToApiQueryError
+  searchQueryTooLongError,
+  searchTimelineClientErrorToApiQueryError,
+  TWITTER_SEARCH_RAW_QUERY_MAX_LENGTH
 } from './searchErrors.js';
 import type { APISearchResults, APITwitterStatus, ApiQueryError } from '../../types/api-schemas.js';
 import type { FetchResults } from '../../types/fetch-results.js';
@@ -436,6 +438,10 @@ export const searchAPI = async (
   host: TwitterBuildHost,
   language?: string
 ): Promise<APISearchResults | ApiQueryError> => {
+  if (query.length > TWITTER_SEARCH_RAW_QUERY_MAX_LENGTH) {
+    return searchQueryTooLongError(query.length);
+  }
+
   const product = feedToProduct(feed);
 
   let response: TwitterSearchTimelineResponse | null;

--- a/packages/atmosphere/src/providers/twitter/searchErrors.ts
+++ b/packages/atmosphere/src/providers/twitter/searchErrors.ts
@@ -1,6 +1,22 @@
 import type { ApiQueryError } from '../../types/api-schemas.js';
 
-export type SearchTimelineClientErrorKind = 'empty_query' | 'blocklisted';
+/** X SearchTimeline rejects `rawQuery` longer than this; match that cap on FxTwitter `/2/search`. */
+export const TWITTER_SEARCH_RAW_QUERY_MAX_LENGTH = 512;
+
+export type SearchTimelineClientErrorKind = 'empty_query' | 'blocklisted' | 'query_too_long';
+
+const QUERY_TOO_LONG_RE = /Raw query length \d+ exceeds max allowed \d+/i;
+
+export function formatSearchQueryTooLongMessage(length: number): string {
+  return `Raw query length ${length} exceeds max allowed ${TWITTER_SEARCH_RAW_QUERY_MAX_LENGTH}`;
+}
+
+export function searchQueryTooLongError(length: number): ApiQueryError {
+  return {
+    code: 400,
+    message: formatSearchQueryTooLongMessage(length)
+  };
+}
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   if (value !== null && typeof value === 'object') {
@@ -49,6 +65,9 @@ export function parseSearchTimelineClientError(
   if (message.includes('denylisted in Search Content Control tool')) {
     return 'blocklisted';
   }
+  if (QUERY_TOO_LONG_RE.test(message)) {
+    return 'query_too_long';
+  }
   return null;
 }
 
@@ -69,6 +88,11 @@ export function searchTimelineClientErrorToApiQueryError(
       return {
         code: 400,
         message: 'Search query is blocked by X content controls'
+      };
+    case 'query_too_long':
+      return {
+        code: 400,
+        message: `Raw query length exceeds max allowed ${TWITTER_SEARCH_RAW_QUERY_MAX_LENGTH}`
       };
   }
 }

--- a/src/realms/api/routes.ts
+++ b/src/realms/api/routes.ts
@@ -5,6 +5,10 @@ import {
   type PublicExploreTimelineKind
 } from '@fxembed/atmosphere/providers/twitter/trends';
 import {
+  formatSearchQueryTooLongMessage,
+  TWITTER_SEARCH_RAW_QUERY_MAX_LENGTH
+} from '@fxembed/atmosphere/providers/twitter/searchErrors';
+import {
   APIProfileRelationshipListSchema,
   APIUserListResultsSchema,
   APISearchResultsSchema,
@@ -22,13 +26,27 @@ import {
 const twitterSearchQueryHasEffectiveContent = (raw: string): boolean =>
   raw.replace(/_/g, '').trim().length > 0;
 
-const twitterSearchQueryString = (openapiMeta: { description: string; example: string }) =>
-  z
+const twitterSearchQueryString = (openapiMeta: {
+  description: string;
+  example: string;
+  maxLength?: number;
+}) => {
+  const maxLength = openapiMeta.maxLength;
+  return z
     .string()
     .refine(twitterSearchQueryHasEffectiveContent, {
       message: 'Search query must not be empty'
     })
+    .superRefine((value, ctx) => {
+      if (maxLength !== undefined && value.length > maxLength) {
+        ctx.addIssue({
+          code: 'custom',
+          message: formatSearchQueryTooLongMessage(value.length)
+        });
+      }
+    })
     .openapi(openapiMeta);
+};
 
 const aboutAccountQuery = z.object({
   about_account: z.string().optional().openapi({
@@ -560,8 +578,9 @@ export const searchV2Route = createRoute({
   request: {
     query: z.object({
       q: twitterSearchQueryString({
-        description: 'Search query (non-empty)',
-        example: 'puppies'
+        description: `Search query (non-empty, max ${TWITTER_SEARCH_RAW_QUERY_MAX_LENGTH} characters)`,
+        example: 'puppies',
+        maxLength: TWITTER_SEARCH_RAW_QUERY_MAX_LENGTH
       }),
       feed: z.enum(['latest', 'top', 'media']).optional().openapi({
         description: 'Search tab (default latest)',
@@ -581,7 +600,7 @@ export const searchV2Route = createRoute({
       content: { 'application/json': { schema: APISearchResultsSchema } }
     },
     400: {
-      description: 'Invalid `q` parameter',
+      description: `Invalid \`q\` parameter (empty or longer than ${TWITTER_SEARCH_RAW_QUERY_MAX_LENGTH} characters)`,
       content: { 'application/json': { schema: ApiQueryErrorSchema } }
     },
     404: {

--- a/test/api.search.test.ts
+++ b/test/api.search.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from 'vitest';
 import type { APITwitterStatus } from '../src/realms/api/schemas';
+import { TWITTER_SEARCH_RAW_QUERY_MAX_LENGTH } from '@fxembed/atmosphere/providers/twitter/searchErrors';
 import { app } from '../src/worker';
 import { botHeaders, twitterBaseUrl } from './helpers/data';
 import harness from './helpers/harness';
@@ -103,6 +104,38 @@ test('API search accepts count parameter', async () => {
   expect(response.code).toEqual(200);
 });
 
+test('API search rejects q longer than 512 characters with 400', async () => {
+  const tooLong = 'a'.repeat(TWITTER_SEARCH_RAW_QUERY_MAX_LENGTH + 1);
+  const result = await app.request(
+    new Request(`https://api.fxtwitter.com/2/search?q=${tooLong}`, {
+      method: 'GET',
+      headers: botHeaders
+    }),
+    undefined,
+    harness
+  );
+  expect(result.status).toEqual(400);
+  const body = (await result.json()) as { code?: number; message?: string; success?: boolean };
+  expect(body.code).toEqual(400);
+  expect(body.message).toContain(
+    `Raw query length ${tooLong.length} exceeds max allowed ${TWITTER_SEARCH_RAW_QUERY_MAX_LENGTH}`
+  );
+  expect(body.success).toBeUndefined();
+});
+
+test('API search accepts q of exactly 512 characters', async () => {
+  const atLimit = 'a'.repeat(TWITTER_SEARCH_RAW_QUERY_MAX_LENGTH);
+  const result = await app.request(
+    new Request(`https://api.fxtwitter.com/2/search?q=${atLimit}`, {
+      method: 'GET',
+      headers: botHeaders
+    }),
+    undefined,
+    harness
+  );
+  expect(result.status).not.toEqual(400);
+});
+
 test('API search returns 400 for upstream empty query error', async () => {
   const result = await app.request(
     new Request('https://api.fxtwitter.com/2/search?q=empty_query_error', {
@@ -131,4 +164,19 @@ test('API search returns 400 for upstream blocklisted query error', async () => 
   const body = (await result.json()) as { code?: number; message?: string };
   expect(body.code).toEqual(400);
   expect(body.message).toContain('blocked by X content controls');
+});
+
+test('API search returns 400 for upstream query too long error', async () => {
+  const result = await app.request(
+    new Request('https://api.fxtwitter.com/2/search?q=query_too_long_error', {
+      method: 'GET',
+      headers: botHeaders
+    }),
+    undefined,
+    harness
+  );
+  expect(result.status).toEqual(400);
+  const body = (await result.json()) as { code?: number; message?: string };
+  expect(body.code).toEqual(400);
+  expect(body.message).toContain(`exceeds max allowed ${TWITTER_SEARCH_RAW_QUERY_MAX_LENGTH}`);
 });

--- a/test/mocks/SearchTimeline/query_too_long_error.json
+++ b/test/mocks/SearchTimeline/query_too_long_error.json
@@ -1,0 +1,21 @@
+{
+  "errors": [
+    {
+      "message": "BadRequest: Raw query length 2268 exceeds max allowed 512",
+      "locations": [{ "line": 4, "column": 7 }],
+      "path": ["search_by_raw_query", "search_timeline", "timeline"],
+      "extensions": {
+        "name": "BadRequestError",
+        "source": "Client",
+        "code": 214,
+        "kind": "Validation",
+        "tracing": { "trace_id": "00000000000000000000000000000000" }
+      },
+      "code": 214,
+      "kind": "Validation",
+      "name": "BadRequestError",
+      "source": "Client"
+    }
+  ],
+  "data": {}
+}

--- a/test/searchTimelineErrors.test.ts
+++ b/test/searchTimelineErrors.test.ts
@@ -1,8 +1,11 @@
 import { test, expect } from 'vitest';
 import {
+  formatSearchQueryTooLongMessage,
   isSearchTimelineClientErrorResponse,
   parseSearchTimelineClientError,
-  searchTimelineClientErrorToApiQueryError
+  searchQueryTooLongError,
+  searchTimelineClientErrorToApiQueryError,
+  TWITTER_SEARCH_RAW_QUERY_MAX_LENGTH
 } from '@fxembed/atmosphere/providers/twitter/searchErrors';
 
 const emptyQueryError = {
@@ -27,6 +30,17 @@ const blocklistedError = {
   data: {}
 };
 
+const queryTooLongError = {
+  errors: [
+    {
+      message: 'BadRequest: Raw query length 2268 exceeds max allowed 512',
+      path: ['search_by_raw_query', 'search_timeline', 'timeline'],
+      code: 214
+    }
+  ],
+  data: {}
+};
+
 test('parseSearchTimelineClientError detects empty query', () => {
   expect(parseSearchTimelineClientError(emptyQueryError)).toBe('empty_query');
   expect(isSearchTimelineClientErrorResponse(emptyQueryError)).toBe(true);
@@ -34,6 +48,11 @@ test('parseSearchTimelineClientError detects empty query', () => {
 
 test('parseSearchTimelineClientError detects blocklisted query', () => {
   expect(parseSearchTimelineClientError(blocklistedError)).toBe('blocklisted');
+});
+
+test('parseSearchTimelineClientError detects query too long', () => {
+  expect(parseSearchTimelineClientError(queryTooLongError)).toBe('query_too_long');
+  expect(isSearchTimelineClientErrorResponse(queryTooLongError)).toBe(true);
 });
 
 test('parseSearchTimelineClientError ignores unrelated GraphQL errors', () => {
@@ -58,6 +77,11 @@ test('parseSearchTimelineClientError accepts known messages without path', () =>
       errors: [{ message: 'BadRequest: Query is denylisted in Search Content Control tool.' }]
     })
   ).toBe('blocklisted');
+  expect(
+    parseSearchTimelineClientError({
+      errors: [{ message: 'BadRequest: Raw query length 2268 exceeds max allowed 512' }]
+    })
+  ).toBe('query_too_long');
 });
 
 test('searchTimelineClientErrorToApiQueryError maps to API 400 messages', () => {
@@ -69,4 +93,18 @@ test('searchTimelineClientErrorToApiQueryError maps to API 400 messages', () => 
     code: 400,
     message: 'Search query is blocked by X content controls'
   });
+  expect(searchTimelineClientErrorToApiQueryError('query_too_long')).toEqual({
+    code: 400,
+    message: `Raw query length exceeds max allowed ${TWITTER_SEARCH_RAW_QUERY_MAX_LENGTH}`
+  });
+});
+
+test('searchQueryTooLongError includes the actual query length', () => {
+  expect(searchQueryTooLongError(2268)).toEqual({
+    code: 400,
+    message: formatSearchQueryTooLongMessage(2268)
+  });
+  expect(formatSearchQueryTooLongMessage(2268)).toBe(
+    'Raw query length 2268 exceeds max allowed 512'
+  );
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
People have been treating `GET /2/search` like an LLM and sending multi-thousand-character prompts. X’s SearchTimeline already rejects `rawQuery` longer than 512 characters (`Raw query length N exceeds max allowed 512`).

This change matches that limit on our own API so we return **400** immediately instead of forwarding junk upstream.

## Behavior

- `q` longer than **512** characters → `{ "code": 400, "message": "q: Raw query length N exceeds max allowed 512" }`
- Exactly 512 characters is still accepted
- Typeahead (`/2/typeahead`) is unchanged
- If X still returns the length validation error, it is mapped to the same 400 shape (and ignored by the proxy retry loop, like empty/blocklisted queries)

## Tests

- API: reject 513-char `q`, accept 512-char `q`, map upstream `query_too_long` mock
- Unit: parse/map Twitter’s `Raw query length … exceeds max allowed 512` message

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05914ff1-9ba5-480a-9c8b-4c6ea7441b1e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05914ff1-9ba5-480a-9c8b-4c6ea7441b1e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Search requests exceeding 512 characters are now rejected with a clear 400 error before processing.
  - Overlong-query errors from the search provider are consistently recognized and reported.
  - Queries at the maximum allowed length continue to work as expected.

- **Documentation**
  - Search API validation and error responses now document the maximum query length and related messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->