### PR TITLE
fix(instagram): rotate accounts on private API status=fail

### DIFF
--- a/docs/src/content/docs/deployment/credentials.mdx
+++ b/docs/src/content/docs/deployment/credentials.mdx
@@ -189,7 +189,7 @@ Mixing the two is the usual cause of an unexpected checkpoint, so keep this cons
 2. Open DevTools → **Application → Cookies → `https://www.instagram.com`**.
 3. Copy the `sessionid`, `ds_user_id`, `csrftoken`, `mid` and `ig_did` values into the fields above, leaving `platform` as `web`.
 
-Sessions are long-lived but not permanent: logging the account out, changing its password, or an Instagram-side checkpoint invalidates the cookie. FxEmbed rotates to the next configured account on `401`, `403` and `429`, and treats an HTML login page as a dead session, so a stale entry degrades one account rather than the whole deployment. Use accounts you're willing to lose, not a personal one.
+Sessions are long-lived but not permanent: logging the account out, changing its password, or an Instagram-side checkpoint invalidates the cookie. FxEmbed rotates to the next configured account on `401`, `403` and `429`, on an HTML login page, and on a 200 `{ status: 'fail' }` body (checkpoint / spam block), so a stale entry degrades one account rather than the whole deployment. Use accounts you're willing to lose, not a personal one.
 
 ### Encryption and Deployment
 

--- a/packages/atmosphere/src/providers/instagram/account-proxy.ts
+++ b/packages/atmosphere/src/providers/instagram/account-proxy.ts
@@ -115,8 +115,9 @@ export type InstagramPrivateApiResult = {
 
 /**
  * Calls an `i.instagram.com/api/v1/…` endpoint through a proxy account, rotating accounts on
- * auth/rate-limit failures. Returns `{ ok: false, status: 0 }` when no proxy account is configured
- * so callers can fall back to their logged-out path.
+ * auth/rate-limit failures and on a 200 `{ status: 'fail' }` body (checkpoint / spam block).
+ * Returns `{ ok: false, status: 0 }` when no proxy account is configured so callers can fall
+ * back to their logged-out path.
  */
 export async function instagramPrivateApiRequest(
   path: string,
@@ -189,16 +190,28 @@ export async function instagramPrivateApiRequest(
       last = { ok: false, status: res.status, json: null, accountUsed: account.username };
       continue;
     }
+    let parsed: unknown;
     try {
-      return {
-        ok: true,
-        status: res.status,
-        json: JSON.parse(text) as unknown,
-        accountUsed: account.username
-      };
+      parsed = JSON.parse(text) as unknown;
     } catch {
       last = { ok: false, status: res.status, json: null, accountUsed: account.username };
+      continue;
     }
+    // The private API answers 200 with `{ status: 'fail' }` for soft failures (checkpoint,
+    // spam block, feedback_required). Rotate rather than surfacing an empty page as success.
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      (parsed as { status?: unknown }).status === 'fail'
+    ) {
+      console.error('[instagram] private API returned status=fail', {
+        path,
+        account: account.username
+      });
+      last = { ok: false, status: 502, json: parsed, accountUsed: account.username };
+      continue;
+    }
+    return { ok: true, status: res.status, json: parsed, accountUsed: account.username };
   }
   return last;
 }

--- a/test/instagram.accountProxy.test.ts
+++ b/test/instagram.accountProxy.test.ts
@@ -178,4 +178,43 @@ describe('instagram account proxy', () => {
     expect(res.accountUsed).toBe('android_account');
     expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
+
+  it('treats a 200 `status: fail` body as a failure worth rotating past', async () => {
+    installProxyRuntime([webAccount, androidAccount]);
+    const fetchSpy = vi.fn(async (_url: string, init: RequestInit) => {
+      const cookie = (init.headers as Record<string, string>)['Cookie'];
+      if (cookie.includes('web-session')) {
+        return new Response(
+          JSON.stringify({ status: 'fail', message: 'checkpoint_required' }),
+          { status: 200 }
+        );
+      }
+      return new Response(JSON.stringify({ status: 'ok', items: [] }), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+    const res = await instagramPrivateApiRequest('/media/1/info/', { credentialKey: 'key' });
+    expect(res.ok).toBe(true);
+    expect(res.json).toEqual({ status: 'ok', items: [] });
+    expect(res.accountUsed).toBe('android_account');
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports 502 when every account answers `status: fail`', async () => {
+    installProxyRuntime([webAccount]);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ status: 'fail', message: 'feedback_required' }), {
+            status: 200
+          })
+      )
+    );
+    const res = await instagramPrivateApiRequest('/friendships/1/followers/', {
+      credentialKey: 'key'
+    });
+    expect(res.ok).toBe(false);
+    expect(res.status).toBe(502);
+    expect(res.json).toEqual({ status: 'fail', message: 'feedback_required' });
+  });
 });

--- a/test/instagram.accountProxy.test.ts
+++ b/test/instagram.accountProxy.test.ts
@@ -184,10 +184,9 @@ describe('instagram account proxy', () => {
     const fetchSpy = vi.fn(async (_url: string, init: RequestInit) => {
       const cookie = (init.headers as Record<string, string>)['Cookie'];
       if (cookie.includes('web-session')) {
-        return new Response(
-          JSON.stringify({ status: 'fail', message: 'checkpoint_required' }),
-          { status: 200 }
-        );
+        return new Response(JSON.stringify({ status: 'fail', message: 'checkpoint_required' }), {
+          status: 200
+        });
       }
       return new Response(JSON.stringify({ status: 'ok', items: [] }), { status: 200 });
     });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Instagram's `instagramPrivateApiRequest` treated any parseable 2xx JSON as success. Instagram commonly answers HTTP 200 with `{ status: 'fail' }` for checkpointed, spam-blocked, or `feedback_required` sessions. That produced `ok: true` with an empty/unusable payload and skipped rotation to the next configured account.

This matches the existing Threads account-proxy behavior:

- Parse JSON first
- If `status === 'fail'`, log, set `ok: false` / `status: 502`, and try the next account
- If every account fails that way, return the last fail payload (not a fake success)

Docs for Instagram credentials now mention this rotation case alongside 401/403/429 and HTML login pages.

## Test plan

- [x] Added unit tests for rotation on `status: fail` and for 502 when every account fails
- [x] `npm run test -- test/instagram.accountProxy.test.ts test/threads.accountProxy.test.ts` — 16 passed

[instagram_account_proxy_tests.log](https://cursor.com/artifacts/c/art-df95c3e7-3e1e-45fb-9bca-85b917001bd9)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-44ff6fb0-742b-4928-beaf-2155c9a9b850?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44ff6fb0-742b-4928-beaf-2155c9a9b850&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

