### PR TITLE
fix(instagram,threads): constrain private-API pages to requested count

### DIFF
--- a/packages/atmosphere/src/providers/instagram/conversation.ts
+++ b/packages/atmosphere/src/providers/instagram/conversation.ts
@@ -120,6 +120,7 @@ export async function constructInstagramConversation(
     const res = await fetchPrivateMediaComments(mediaPk, ctx, {
       accounts,
       maxId,
+      count,
       sortOrder: options.sortOrder,
       shortcode
     });

--- a/packages/atmosphere/src/providers/instagram/private-api.ts
+++ b/packages/atmosphere/src/providers/instagram/private-api.ts
@@ -65,6 +65,7 @@ export function fetchPrivateMediaComments(
   options: InstagramApiOptions & {
     maxId?: string | null;
     minId?: string | null;
+    count?: number;
     sortOrder?: 'popular' | 'recent';
     shortcode?: string;
   } = {}
@@ -74,6 +75,7 @@ export function fetchPrivateMediaComments(
       can_support_threading: 'true',
       permalink_enabled: 'false',
       sort_order: options.sortOrder ?? 'popular',
+      count: options.count,
       max_id: options.maxId ?? undefined,
       min_id: options.minId ?? undefined
     },

--- a/packages/atmosphere/src/providers/threads/conversation.ts
+++ b/packages/atmosphere/src/providers/threads/conversation.ts
@@ -70,6 +70,7 @@ async function proxiedConversation(params: {
   const res = await fetchThreadsPostReplies(params.mediaId, params.ctx, {
     accounts,
     sortOrder,
+    count: params.count,
     pagingToken: params.pagingToken,
     shortcode: params.shortcode
   });

--- a/packages/atmosphere/src/providers/threads/private-api.ts
+++ b/packages/atmosphere/src/providers/threads/private-api.ts
@@ -50,6 +50,7 @@ export function fetchThreadsProfileFeed(
   ctx: ThreadsRequestContext | undefined,
   options: ThreadsApiOptions & {
     maxId?: string | null;
+    count?: number;
     username?: string;
   } = {}
 ): Promise<ThreadsPrivateApiResult> {
@@ -57,6 +58,7 @@ export function fetchThreadsProfileFeed(
     pathParams: { user_id: userId },
     query: {
       user_id: userId,
+      count: options.count,
       max_id: options.maxId ?? undefined,
       is_app_start: false
     },
@@ -71,6 +73,7 @@ export function fetchThreadsPostReplies(
   ctx: ThreadsRequestContext | undefined,
   options: ThreadsApiOptions & {
     pagingToken?: string | null;
+    count?: number;
     sortOrder?: 'top' | 'all';
     shortcode?: string;
     username?: string;
@@ -81,6 +84,7 @@ export function fetchThreadsPostReplies(
     query: {
       post_id: postId,
       sort_order: options.sortOrder ?? 'top',
+      count: options.count,
       paging_token: options.pagingToken ?? undefined,
       check_for_unavailable_replies: true
     },

--- a/packages/atmosphere/src/providers/threads/profile-tabs.ts
+++ b/packages/atmosphere/src/providers/threads/profile-tabs.ts
@@ -57,6 +57,7 @@ export async function constructThreadsProfileTab(
   const res = await fetchThreadsProfileFeed(userId, tab, options.ctx, {
     accounts,
     maxId,
+    count,
     username: handle
   });
   if (!res.ok) {

--- a/test/instagram.proxiedPost.test.ts
+++ b/test/instagram.proxiedPost.test.ts
@@ -157,6 +157,75 @@ describe('Instagram post and conversation through the account proxy', () => {
     expect(requested.some(u => u.includes('max_id=COMMENTS2'))).toBe(true);
   });
 
+  it('asks the comments API for count and surfaces the next comment on the following page', async () => {
+    installProxy();
+    const comments = [
+      {
+        pk: '18000000000000001',
+        text: 'first',
+        created_at: 1770000100,
+        user: { pk: 99, username: 'fan', full_name: 'A Fan' }
+      },
+      {
+        pk: '18000000000000002',
+        text: 'second',
+        created_at: 1770000200,
+        user: { pk: 98, username: 'other', full_name: 'Someone Else' }
+      }
+    ];
+    const requested: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: string) => {
+        const url = new URL(input);
+        requested.push(url.pathname + url.search);
+        if (url.pathname.startsWith(`/api/v1/media/${MEDIA_PK}/info/`)) {
+          return new Response(JSON.stringify({ items: [mediaItem] }), { status: 200 });
+        }
+        if (url.pathname.startsWith(`/api/v1/media/${MEDIA_PK}/comments/`)) {
+          const count = Number(url.searchParams.get('count') ?? 20);
+          const maxId = url.searchParams.get('max_id');
+          const start = maxId === 'C2' ? 1 : 0;
+          const page = comments.slice(start, start + count);
+          const hasMore = start + count < comments.length;
+          return new Response(
+            JSON.stringify({
+              comments: page,
+              next_max_id: hasMore ? 'C2' : undefined,
+              has_more_comments: hasMore
+            }),
+            { status: 200 }
+          );
+        }
+        return new Response('{}', { status: 404 });
+      })
+    );
+
+    const page1 = await constructInstagramConversation(SHORTCODE, {
+      cursor: null,
+      count: 1,
+      sortOrder: 'popular',
+      userAgent: 'FxEmbedTest/1.0',
+      credentialKey
+    });
+    expect(page1.ok).toBe(true);
+    if (!page1.ok) return;
+    expect(page1.data.replies?.map(r => r.text)).toEqual(['first']);
+    expect(requested.some(u => u.includes('/comments/') && u.includes('count=1'))).toBe(true);
+
+    const page2 = await constructInstagramConversation(SHORTCODE, {
+      cursor: page1.data.cursor?.bottom ?? null,
+      count: 1,
+      sortOrder: 'popular',
+      userAgent: 'FxEmbedTest/1.0',
+      credentialKey
+    });
+    expect(page2.ok).toBe(true);
+    if (!page2.ok) return;
+    expect(page2.data.replies?.map(r => r.text)).toEqual(['second']);
+    expect(requested.some(u => u.includes('max_id=C2'))).toBe(true);
+  });
+
   it('refuses a GraphQL cursor on the proxy path rather than serving the wrong page', async () => {
     installProxy();
     stubApi({

--- a/test/threads.proxiedSurfaces.test.ts
+++ b/test/threads.proxiedSurfaces.test.ts
@@ -360,6 +360,117 @@ describe('proxied Threads surfaces', () => {
     expect(requested[0]).toContain('sort_order=top');
   });
 
+  it('asks replies for count and surfaces the next reply on the following page', async () => {
+    installProxy();
+    const focal = {
+      pk: '1',
+      code: 'DXhZAMkljvS',
+      taken_at: 1700000000,
+      caption: { text: 'focal' },
+      user: { pk: 314216, username: 'zuck' }
+    };
+    const replies = [threadRow('AAA', 'first reply'), threadRow('BBB', 'second reply')];
+    const requested: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: string) => {
+        const url = new URL(input);
+        requested.push(url.pathname + url.search);
+        if (!url.pathname.includes('/replies/')) {
+          return new Response('{}', { status: 404 });
+        }
+        const count = Number(url.searchParams.get('count') ?? 20);
+        const token = url.searchParams.get('paging_token');
+        const start = token === 'R2' ? 1 : 0;
+        const page = replies.slice(start, start + count);
+        const hasMore = start + count < replies.length;
+        return new Response(
+          JSON.stringify({
+            containing_thread: { thread_items: [{ post: focal }] },
+            reply_threads: page,
+            paging_tokens: hasMore ? { downwards: 'R2' } : undefined,
+            has_more: hasMore
+          }),
+          { status: 200 }
+        );
+      })
+    );
+
+    const page1 = await constructThreadsConversation('DXhZAMkljvS', {
+      cursor: null,
+      count: 1,
+      sortOrder: 'top',
+      ctx
+    });
+    expect(page1.ok).toBe(true);
+    if (!page1.ok) return;
+    expect(page1.data.replies?.map(r => r.id)).toEqual(['AAA']);
+    expect(requested.some(u => u.includes('/replies/') && u.includes('count=1'))).toBe(true);
+
+    const page2 = await constructThreadsConversation('DXhZAMkljvS', {
+      cursor: page1.data.cursor?.bottom ?? null,
+      count: 1,
+      sortOrder: 'top',
+      ctx
+    });
+    expect(page2.ok).toBe(true);
+    if (!page2.ok) return;
+    expect(page2.data.replies?.map(r => r.id)).toEqual(['BBB']);
+    expect(requested.some(u => u.includes('paging_token=R2'))).toBe(true);
+  });
+
+  it('asks the profile feed for count and surfaces the next post on the following page', async () => {
+    installProxy();
+    const items = [threadRow('AAA', 'first'), threadRow('BBB', 'second')];
+    const requested: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: string) => {
+        const url = new URL(input);
+        requested.push(url.pathname + url.search);
+        if (url.pathname.startsWith('/api/v1/users/zuck/usernameinfo/')) {
+          return new Response(JSON.stringify(zuck), { status: 200 });
+        }
+        if (url.pathname.startsWith('/api/v1/text_feed/314216/profile/replies/')) {
+          const count = Number(url.searchParams.get('count') ?? 20);
+          const maxId = url.searchParams.get('max_id');
+          const start = maxId === 'PAGE2' ? 1 : 0;
+          const page = items.slice(start, start + count);
+          const hasMore = start + count < items.length;
+          return new Response(
+            JSON.stringify({
+              items: page,
+              paging_tokens: hasMore ? { downwards: 'PAGE2' } : undefined,
+              has_more: hasMore
+            }),
+            { status: 200 }
+          );
+        }
+        return new Response('{}', { status: 404 });
+      })
+    );
+
+    const page1 = await constructThreadsProfileTab('zuck', 'replies', {
+      count: 1,
+      cursor: null,
+      ctx
+    });
+    expect(page1.code).toBe(200);
+    expect(page1.results.map(s => s.id)).toEqual(['AAA']);
+    expect(requested.some(u => u.includes('/profile/replies/') && u.includes('count=1'))).toBe(
+      true
+    );
+
+    const page2 = await constructThreadsProfileTab('zuck', 'replies', {
+      count: 1,
+      cursor: page1.cursor.bottom,
+      ctx
+    });
+    expect(page2.code).toBe(200);
+    expect(page2.results.map(s => s.id)).toEqual(['BBB']);
+    expect(requested.some(u => u.includes('max_id=PAGE2'))).toBe(true);
+  });
+
   it('resolves a profile through usernameinfo when a proxy is available', async () => {
     installProxy();
     const requested = stubApi({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Instagram private comments and Threads replies/profile-feed pagination truncated locally to `count` while the next-page cursor came from the unconstrained API response. That skipped items when `count` was smaller than the API's default page.

This passes `count` on those fetches so the cursor matches the page we actually return.

- `fetchPrivateMediaComments` accepts and sends `count`; conversation flow passes it
- `fetchThreadsPostReplies` and `fetchThreadsProfileFeed` do the same
- Tests with `count: 1` confirm the second item appears on the following page

Local verification: atmosphere eslint is clean; 34 tests across the Instagram/Threads proxy suites passed, including the new count-1 pagination cases.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55cf9fbb-a0ed-4837-82b8-86010eaae62f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55cf9fbb-a0ed-4837-82b8-86010eaae62f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

