### PR TITLE
fix(threads): decode search cursors as UTF-8 before JSON.parse

### DIFF
--- a/packages/atmosphere/src/providers/threads/cursors.ts
+++ b/packages/atmosphere/src/providers/threads/cursors.ts
@@ -174,7 +174,12 @@ export function decodeThreadsSearchCursor(raw: string): ThreadsSearchCursorV1 | 
   const json = b64urlDecode(raw);
   if (!json) return null;
   try {
-    const o = JSON.parse(json) as Partial<ThreadsSearchCursorV1>;
+    const bytes = new Uint8Array(json.length);
+    for (let i = 0; i < json.length; i++) {
+      bytes[i] = json.charCodeAt(i);
+    }
+    const text = new TextDecoder('utf-8').decode(bytes);
+    const o = JSON.parse(text) as Partial<ThreadsSearchCursorV1>;
     if (o.v !== 1 || typeof o.q !== 'string' || typeof o.r !== 'boolean') return null;
     if (!validCount(o.c)) return null;
     if (typeof o.p !== 'number' || !Number.isFinite(o.p) || o.p < 0) return null;

--- a/test/threads.cursors.test.ts
+++ b/test/threads.cursors.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest';
 import {
   decodeThreadsConversationCursor,
   decodeThreadsProfileTimelineCursor,
+  decodeThreadsSearchCursor,
   encodeThreadsConversationCursor,
-  encodeThreadsProfileTimelineCursor
+  encodeThreadsProfileTimelineCursor,
+  encodeThreadsSearchCursor
 } from '@fxembed/atmosphere/providers/threads/cursors';
 
 describe('threads conversation cursor', () => {
@@ -74,5 +76,25 @@ describe('threads profile timeline cursor', () => {
       after: 'QVFD',
       count: 11
     });
+  });
+});
+
+describe('threads search cursor', () => {
+  it('round-trips UTF-8 query text', () => {
+    const payload = {
+      v: 1 as const,
+      q: 'café 日本語 🧵',
+      r: false,
+      t: 'PAGE2',
+      rt: 'RANK',
+      p: 1,
+      c: 20
+    };
+    expect(decodeThreadsSearchCursor(encodeThreadsSearchCursor(payload))).toEqual(payload);
+  });
+
+  it('returns null for invalid input', () => {
+    expect(decodeThreadsSearchCursor('not-a-cursor')).toBeNull();
+    expect(decodeThreadsSearchCursor('')).toBeNull();
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
`encodeThreadsSearchCursor` stores JSON as UTF-8 bytes (via `TextEncoder` + `btoa`), but `decodeThreadsSearchCursor` was passing the `atob` binary string straight to `JSON.parse`. That is fine for ASCII queries and corrupts anything with non-ASCII text (accented Latin, CJK, emoji).

This converts the decoded bytes with `TextDecoder('utf-8')` before parsing, and leaves the existing shape checks and `null` return on invalid input unchanged.

## Test plan
- [x] `npx vitest run test/threads.cursors.test.ts test/threads.proxiedSurfaces.test.ts` — 19 passed
- [x] UTF-8 query round-trip (`café 日本語 🧵`)
- [x] Invalid input still returns `null`
- [x] Existing ASCII search cursor decode in proxied-surfaces tests still passes
- [x] Atmosphere ESLint (`npm run lint:eslint -w @fxembed/atmosphere`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4156d7ab-5c43-4d9e-82ae-a29783079802?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4156d7ab-5c43-4d9e-82ae-a29783079802&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

