### PR TITLE
fix(threads): apply request timeout to private API body read

### DIFF
--- a/packages/atmosphere/src/providers/threads/account-proxy.ts
+++ b/packages/atmosphere/src/providers/threads/account-proxy.ts
@@ -149,15 +149,33 @@ export async function threadsPrivateApiRequest(
       headers['Content-Type'] = 'application/x-www-form-urlencoded';
     }
     let res: Response;
+    let text = '';
+    let parsed: unknown;
+    let parseFailed = false;
     try {
-      res = await withTimeout(signal =>
-        fetch(url.toString(), {
+      // Fetch can resolve on headers; keep body read + JSON.parse inside the timeout so a
+      // stalled body aborts and rotates instead of hanging the request.
+      const timed = await withTimeout(async signal => {
+        const response = await fetch(url.toString(), {
           method: options.method ?? 'GET',
           headers,
           body: options.method === 'POST' ? (options.body ?? '') : undefined,
           signal
-        })
-      );
+        });
+        if (!response.ok) {
+          return { response, text: '', parsed: null, parseFailed: false };
+        }
+        const body = await response.text();
+        try {
+          return { response, text: body, parsed: JSON.parse(body) as unknown, parseFailed: false };
+        } catch {
+          return { response, text: body, parsed: null, parseFailed: true };
+        }
+      });
+      res = timed.response;
+      text = timed.text;
+      parsed = timed.parsed;
+      parseFailed = timed.parseFailed;
     } catch (err) {
       console.error('[threads] private API request threw', {
         path: resolvedPath,
@@ -179,7 +197,6 @@ export async function threadsPrivateApiRequest(
       return last;
     }
 
-    const text = await res.text();
     const trimmed = text.trim();
     // A logged-out or checkpointed session gets an HTML login page rather than JSON.
     if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) {
@@ -190,10 +207,7 @@ export async function threadsPrivateApiRequest(
       last = { ok: false, status: res.status, json: null, accountUsed: account.username };
       continue;
     }
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(text) as unknown;
-    } catch {
+    if (parseFailed) {
       last = { ok: false, status: res.status, json: null, accountUsed: account.username };
       continue;
     }

--- a/packages/atmosphere/src/providers/threads/account-proxy.ts
+++ b/packages/atmosphere/src/providers/threads/account-proxy.ts
@@ -149,9 +149,9 @@ export async function threadsPrivateApiRequest(
       headers['Content-Type'] = 'application/x-www-form-urlencoded';
     }
     let res: Response;
-    let text = '';
+    let text: string;
     let parsed: unknown;
-    let parseFailed = false;
+    let parseFailed: boolean;
     try {
       // Fetch can resolve on headers; keep body read + JSON.parse inside the timeout so a
       // stalled body aborts and rotates instead of hanging the request.

--- a/test/threads.accountProxy.test.ts
+++ b/test/threads.accountProxy.test.ts
@@ -155,4 +155,82 @@ describe('threads account proxy', () => {
     expect(res.ok).toBe(false);
     expect(res.status).toBe(502);
   });
+
+  it('treats an HTML login page as a dead session and tries the next account', async () => {
+    installProxyRuntime([webAccount, androidAccount]);
+    const fetchSpy = vi.fn(async (_url: string, init: RequestInit) => {
+      const cookie = String((init.headers as Record<string, string>)['Cookie']);
+      if (cookie.includes('web-session')) {
+        return new Response('<!DOCTYPE html><html>login</html>', { status: 200 });
+      }
+      return new Response(JSON.stringify({ items: [] }), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+    const res = await threadsPrivateApiRequest('fbsearch/text_app/trends/', {
+      credentialKey: 'key'
+    });
+    expect(res.ok).toBe(true);
+    expect(res.accountUsed).toBe('android_account');
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the HTTP status when JSON.parse fails and rotates', async () => {
+    installProxyRuntime([webAccount, androidAccount]);
+    const fetchSpy = vi.fn(async (_url: string, init: RequestInit) => {
+      const cookie = String((init.headers as Record<string, string>)['Cookie']);
+      if (cookie.includes('web-session')) {
+        return new Response('{not json', { status: 200 });
+      }
+      return new Response(JSON.stringify({ status: 'ok' }), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+    const res = await threadsPrivateApiRequest('fbsearch/text_app/trends/', {
+      credentialKey: 'key'
+    });
+    expect(res.ok).toBe(true);
+    expect(res.accountUsed).toBe('android_account');
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports the HTTP status as last result when malformed JSON is the only response', async () => {
+    installProxyRuntime([webAccount]);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('{not json', { status: 200 }))
+    );
+    const res = await threadsPrivateApiRequest('fbsearch/text_app/trends/', {
+      credentialKey: 'key'
+    });
+    expect(res.ok).toBe(false);
+    expect(res.status).toBe(200);
+    expect(res.json).toBeNull();
+    expect(res.accountUsed).toBe('web_account');
+  });
+
+  it('rotates when the response body aborts inside the request timeout', async () => {
+    installProxyRuntime([webAccount, androidAccount]);
+    const fetchSpy = vi.fn(async (_url: string, init: RequestInit) => {
+      const cookie = String((init.headers as Record<string, string>)['Cookie']);
+      if (cookie.includes('web-session')) {
+        return {
+          ok: true,
+          status: 200,
+          async text() {
+            const err = new Error('The operation was aborted');
+            err.name = 'AbortError';
+            throw err;
+          }
+        } as Response;
+      }
+      return new Response(JSON.stringify({ status: 'ok', items: [] }), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+    const res = await threadsPrivateApiRequest('fbsearch/text_app/trends/', {
+      credentialKey: 'key'
+    });
+    expect(res.ok).toBe(true);
+    expect(res.accountUsed).toBe('android_account');
+    // withTimeout retries the whole fetch+body read 4 times (initial + 3) before rotating.
+    expect(fetchSpy).toHaveBeenCalledTimes(5);
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- `threadsPrivateApiRequest` currently times out only the `fetch()` call. `fetch` can resolve when headers arrive, so a stalled `res.text()` hangs forever and never rotates accounts.
- Body read and `JSON.parse` now run inside the existing `withTimeout` callback. An incomplete body aborts, retries, then rotates.
- Non-JSON (HTML login) handling and last-result status on parse failure are unchanged. Error HTTP statuses still skip the body read so 401/403/429 rotate immediately.

## Test plan
- `npm test -- test/threads.accountProxy.test.ts`
- Covers HTML non-JSON rotation, malformed JSON last-result (`status` stays 200), and `AbortError` during `text()` rotating after `withTimeout` retries.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2a75b0a-6e41-47e3-af49-77c2b937a5ef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2a75b0a-6e41-47e3-af49-77c2b937a5ef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

