### PR TITLE
fix(threads): keep account-proxy cookies off auto-followed redirects

### DIFF
--- a/packages/atmosphere/src/helpers/index.ts
+++ b/packages/atmosphere/src/helpers/index.ts
@@ -1,5 +1,6 @@
 export * from './unescape-text.js';
 export * from './with-timeout.js';
+export * from './same-origin-https-fetch.js';
 export * from './unicode-string.js';
 export * from './twitter-text-indices.js';
 export * from './language.js';

--- a/packages/atmosphere/src/helpers/same-origin-https-fetch.ts
+++ b/packages/atmosphere/src/helpers/same-origin-https-fetch.ts
@@ -1,0 +1,36 @@
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+/** Cap so a same-origin loop cannot burn the request timeout on hop after hop. */
+const MAX_SAME_ORIGIN_REDIRECTS = 5;
+
+/** Next hop if Location is https and same-origin as `from`; otherwise null (do not follow). */
+export function sameOriginHttpsRedirectUrl(from: string, location: string | null): string | null {
+  if (!location) return null;
+  try {
+    const current = new URL(from);
+    const next = new URL(location, from);
+    if (next.protocol !== 'https:') return null;
+    if (next.origin !== current.origin) return null;
+    return next.href;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * `fetch` that does not auto-follow redirects. workerd rejects `redirect: 'error'`
+ * ("won't be implemented"); `manual` plus same-origin HTTPS checks keep session cookies
+ * off cross-origin Location hops.
+ */
+export async function fetchSameOriginHttps(url: string, init: RequestInit): Promise<Response> {
+  const requestInit: RequestInit = { ...init, redirect: 'manual' };
+  let requestUrl = url;
+  let response = await fetch(requestUrl, requestInit);
+  for (let hop = 0; hop < MAX_SAME_ORIGIN_REDIRECTS; hop++) {
+    if (!REDIRECT_STATUSES.has(response.status)) break;
+    const nextUrl = sameOriginHttpsRedirectUrl(requestUrl, response.headers.get('Location'));
+    if (!nextUrl) break;
+    requestUrl = nextUrl;
+    response = await fetch(requestUrl, requestInit);
+  }
+  return response;
+}

--- a/packages/atmosphere/src/providers/instagram/account-proxy.ts
+++ b/packages/atmosphere/src/providers/instagram/account-proxy.ts
@@ -1,3 +1,4 @@
+import { fetchSameOriginHttps } from '../../helpers/same-origin-https-fetch.js';
 import { withTimeout } from '../../helpers/with-timeout.js';
 import { getInstagramProviderEnv, getInstagramProxyRuntime } from '../instagram-runtime.js';
 import type { InstagramCredentials } from '../../types/proxy-credentials.js';
@@ -151,7 +152,7 @@ export async function instagramPrivateApiRequest(
     let res: Response;
     try {
       res = await withTimeout(signal =>
-        fetch(url.toString(), {
+        fetchSameOriginHttps(url.toString(), {
           method: options.method ?? 'GET',
           headers,
           body: options.method === 'POST' ? (options.body ?? '') : undefined,

--- a/packages/atmosphere/src/providers/threads/account-proxy.ts
+++ b/packages/atmosphere/src/providers/threads/account-proxy.ts
@@ -1,3 +1,4 @@
+import { fetchSameOriginHttps } from '../../helpers/same-origin-https-fetch.js';
 import { withTimeout } from '../../helpers/with-timeout.js';
 import { getInstagramProviderEnv } from '../instagram-runtime.js';
 import {
@@ -87,24 +88,6 @@ export function threadsProxyHeaders(
 /** HTTP statuses where another account is worth trying: auth/checkpoint/rate limit. */
 const ROTATE_STATUSES = new Set([401, 403, 429]);
 
-const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
-/** Cap so a same-origin loop cannot burn the request timeout on hop after hop. */
-const MAX_SAME_ORIGIN_REDIRECTS = 5;
-
-/** Next hop if Location is https and same-origin as `from`; otherwise null (do not follow). */
-function sameOriginHttpsRedirectUrl(from: string, location: string | null): string | null {
-  if (!location) return null;
-  try {
-    const current = new URL(from);
-    const next = new URL(location, from);
-    if (next.protocol !== 'https:') return null;
-    if (next.origin !== current.origin) return null;
-    return next.href;
-  } catch {
-    return null;
-  }
-}
-
 export type ThreadsPrivateApiResult = {
   ok: boolean;
   /** 0 when no account was available at all (proxy not configured). */
@@ -174,24 +157,12 @@ export async function threadsPrivateApiRequest(
       // Fetch can resolve on headers; keep body read + JSON.parse inside the timeout so a
       // stalled body aborts and rotates instead of hanging the request.
       const timed = await withTimeout(async signal => {
-        const init: RequestInit = {
+        const response = await fetchSameOriginHttps(url.toString(), {
           method: options.method ?? 'GET',
           headers,
           body: options.method === 'POST' ? (options.body ?? '') : undefined,
-          signal,
-          // workerd rejects redirect: 'error' ("won't be implemented"). manual plus
-          // same-origin HTTPS checks keep session cookies off cross-origin Location hops.
-          redirect: 'manual'
-        };
-        let requestUrl = url.toString();
-        let response = await fetch(requestUrl, init);
-        for (let hop = 0; hop < MAX_SAME_ORIGIN_REDIRECTS; hop++) {
-          if (!REDIRECT_STATUSES.has(response.status)) break;
-          const nextUrl = sameOriginHttpsRedirectUrl(requestUrl, response.headers.get('Location'));
-          if (!nextUrl) break;
-          requestUrl = nextUrl;
-          response = await fetch(requestUrl, init);
-        }
+          signal
+        });
         if (!response.ok) {
           return { response, text: '', parsed: null, parseFailed: false };
         }

--- a/packages/atmosphere/src/providers/threads/account-proxy.ts
+++ b/packages/atmosphere/src/providers/threads/account-proxy.ts
@@ -87,6 +87,24 @@ export function threadsProxyHeaders(
 /** HTTP statuses where another account is worth trying: auth/checkpoint/rate limit. */
 const ROTATE_STATUSES = new Set([401, 403, 429]);
 
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+/** Cap so a same-origin loop cannot burn the request timeout on hop after hop. */
+const MAX_SAME_ORIGIN_REDIRECTS = 5;
+
+/** Next hop if Location is https and same-origin as `from`; otherwise null (do not follow). */
+function sameOriginHttpsRedirectUrl(from: string, location: string | null): string | null {
+  if (!location) return null;
+  try {
+    const current = new URL(from);
+    const next = new URL(location, from);
+    if (next.protocol !== 'https:') return null;
+    if (next.origin !== current.origin) return null;
+    return next.href;
+  } catch {
+    return null;
+  }
+}
+
 export type ThreadsPrivateApiResult = {
   ok: boolean;
   /** 0 when no account was available at all (proxy not configured). */
@@ -156,12 +174,24 @@ export async function threadsPrivateApiRequest(
       // Fetch can resolve on headers; keep body read + JSON.parse inside the timeout so a
       // stalled body aborts and rotates instead of hanging the request.
       const timed = await withTimeout(async signal => {
-        const response = await fetch(url.toString(), {
+        const init: RequestInit = {
           method: options.method ?? 'GET',
           headers,
           body: options.method === 'POST' ? (options.body ?? '') : undefined,
-          signal
-        });
+          signal,
+          // workerd rejects redirect: 'error' ("won't be implemented"). manual plus
+          // same-origin HTTPS checks keep session cookies off cross-origin Location hops.
+          redirect: 'manual'
+        };
+        let requestUrl = url.toString();
+        let response = await fetch(requestUrl, init);
+        for (let hop = 0; hop < MAX_SAME_ORIGIN_REDIRECTS; hop++) {
+          if (!REDIRECT_STATUSES.has(response.status)) break;
+          const nextUrl = sameOriginHttpsRedirectUrl(requestUrl, response.headers.get('Location'));
+          if (!nextUrl) break;
+          requestUrl = nextUrl;
+          response = await fetch(requestUrl, init);
+        }
         if (!response.ok) {
           return { response, text: '', parsed: null, parseFailed: false };
         }

--- a/test/instagram.accountProxy.test.ts
+++ b/test/instagram.accountProxy.test.ts
@@ -216,4 +216,76 @@ describe('instagram account proxy', () => {
     expect(res.status).toBe(502);
     expect(res.json).toEqual({ status: 'fail', message: 'feedback_required' });
   });
+
+  it('does not auto-follow redirects and skips off-origin Location hops', async () => {
+    installProxyRuntime([webAccount]);
+    const fetchSpy = vi.fn(async (input: string) => {
+      if (String(input).includes('evil.example')) {
+        return new Response(JSON.stringify({ status: 'ok', leaked: true }), { status: 200 });
+      }
+      return new Response(null, {
+        status: 302,
+        headers: { Location: 'https://evil.example/steal' }
+      });
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+    const res = await instagramPrivateApiRequest('/users/x/usernameinfo/', {
+      credentialKey: 'key'
+    });
+    expect(res.ok).toBe(false);
+    expect(res.status).toBe(302);
+    expect(res.json).toBeNull();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0][1]).toMatchObject({ redirect: 'manual' });
+  });
+
+  it('does not follow http Location even on the same host', async () => {
+    installProxyRuntime([webAccount]);
+    const fetchSpy = vi.fn(async (input: string) => {
+      if (String(input).startsWith('http://')) {
+        return new Response(JSON.stringify({ status: 'ok' }), { status: 200 });
+      }
+      return new Response(null, {
+        status: 302,
+        headers: { Location: 'http://i.instagram.com/api/v1/users/x/usernameinfo/' }
+      });
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+    const res = await instagramPrivateApiRequest('/users/x/usernameinfo/', {
+      credentialKey: 'key'
+    });
+    expect(res.ok).toBe(false);
+    expect(res.status).toBe(302);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('follows same-origin HTTPS redirects with the original cookies', async () => {
+    installProxyRuntime([webAccount]);
+    const fetchSpy = vi.fn(async (input: string, init: RequestInit) => {
+      const href = String(input);
+      expect(String((init.headers as Record<string, string>)['Cookie'])).toContain(
+        'sessionid=web-session'
+      );
+      if (href.includes('/canonical/')) {
+        return new Response(JSON.stringify({ status: 'ok', user: { pk: 1 } }), { status: 200 });
+      }
+      return new Response(null, {
+        status: 302,
+        headers: {
+          Location: 'https://i.instagram.com/api/v1/users/x/usernameinfo/canonical/'
+        }
+      });
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+    const res = await instagramPrivateApiRequest('/users/x/usernameinfo/', {
+      credentialKey: 'key'
+    });
+    expect(res.ok).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy.mock.calls[0][1]).toMatchObject({ redirect: 'manual' });
+    expect(fetchSpy.mock.calls[1][1]).toMatchObject({ redirect: 'manual' });
+    expect(String(fetchSpy.mock.calls[1][0])).toBe(
+      'https://i.instagram.com/api/v1/users/x/usernameinfo/canonical/'
+    );
+  });
 });

--- a/test/sameOriginHttpsFetch.test.ts
+++ b/test/sameOriginHttpsFetch.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchSameOriginHttps, sameOriginHttpsRedirectUrl } from '@fxembed/atmosphere/helpers';
+
+const FROM = 'https://i.instagram.com/api/v1/users/x/usernameinfo/';
+
+describe('sameOriginHttpsRedirectUrl', () => {
+  it('accepts https same-origin absolute and relative Location', () => {
+    expect(sameOriginHttpsRedirectUrl(FROM, 'https://i.instagram.com/api/v1/canonical/')).toBe(
+      'https://i.instagram.com/api/v1/canonical/'
+    );
+    expect(sameOriginHttpsRedirectUrl(FROM, '/api/v1/canonical/')).toBe(
+      'https://i.instagram.com/api/v1/canonical/'
+    );
+  });
+
+  it('rejects off-origin, http, protocol-relative, and junk Location', () => {
+    expect(sameOriginHttpsRedirectUrl(FROM, 'https://evil.example/steal')).toBeNull();
+    expect(
+      sameOriginHttpsRedirectUrl(FROM, 'http://i.instagram.com/api/v1/users/x/usernameinfo/')
+    ).toBeNull();
+    expect(sameOriginHttpsRedirectUrl(FROM, '//evil.example/steal')).toBeNull();
+    expect(sameOriginHttpsRedirectUrl(FROM, 'https://i.instagram.com.evil.example/')).toBeNull();
+    expect(sameOriginHttpsRedirectUrl(FROM, null)).toBeNull();
+    expect(sameOriginHttpsRedirectUrl(FROM, '::::')).toBeNull();
+  });
+});
+
+describe('fetchSameOriginHttps', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('forces redirect: manual and stops at an off-origin hop', async () => {
+    const fetchSpy = vi.fn(async () => {
+      return new Response(null, {
+        status: 302,
+        headers: { Location: 'https://evil.example/steal' }
+      });
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+    const res = await fetchSameOriginHttps(FROM, { headers: { Cookie: 'sessionid=s' } });
+    expect(res.status).toBe(302);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0][1]).toMatchObject({ redirect: 'manual' });
+  });
+});

--- a/test/sameOriginHttpsFetch.test.ts
+++ b/test/sameOriginHttpsFetch.test.ts
@@ -21,7 +21,7 @@ describe('sameOriginHttpsRedirectUrl', () => {
     expect(sameOriginHttpsRedirectUrl(FROM, '//evil.example/steal')).toBeNull();
     expect(sameOriginHttpsRedirectUrl(FROM, 'https://i.instagram.com.evil.example/')).toBeNull();
     expect(sameOriginHttpsRedirectUrl(FROM, null)).toBeNull();
-    expect(sameOriginHttpsRedirectUrl(FROM, '::::')).toBeNull();
+    expect(sameOriginHttpsRedirectUrl(FROM, 'http://[')).toBeNull();
   });
 });
 

--- a/test/threads.accountProxy.test.ts
+++ b/test/threads.accountProxy.test.ts
@@ -233,4 +233,76 @@ describe('threads account proxy', () => {
     // withTimeout retries the whole fetch+body read 4 times (initial + 3) before rotating.
     expect(fetchSpy).toHaveBeenCalledTimes(5);
   });
+
+  it('does not auto-follow redirects and skips off-origin Location hops', async () => {
+    installProxyRuntime([webAccount]);
+    const fetchSpy = vi.fn(async (input: string) => {
+      if (String(input).includes('evil.example')) {
+        return new Response(JSON.stringify({ status: 'ok', leaked: true }), { status: 200 });
+      }
+      return new Response(null, {
+        status: 302,
+        headers: { Location: 'https://evil.example/steal' }
+      });
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+    const res = await threadsPrivateApiRequest('fbsearch/text_app/trends/', {
+      credentialKey: 'key'
+    });
+    expect(res.ok).toBe(false);
+    expect(res.status).toBe(302);
+    expect(res.json).toBeNull();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0][1]).toMatchObject({ redirect: 'manual' });
+  });
+
+  it('does not follow http Location even on the same host', async () => {
+    installProxyRuntime([webAccount]);
+    const fetchSpy = vi.fn(async (input: string) => {
+      if (String(input).startsWith('http://')) {
+        return new Response(JSON.stringify({ status: 'ok' }), { status: 200 });
+      }
+      return new Response(null, {
+        status: 302,
+        headers: { Location: 'http://i.instagram.com/api/v1/fbsearch/text_app/trends/' }
+      });
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+    const res = await threadsPrivateApiRequest('fbsearch/text_app/trends/', {
+      credentialKey: 'key'
+    });
+    expect(res.ok).toBe(false);
+    expect(res.status).toBe(302);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('follows same-origin HTTPS redirects with the original cookies', async () => {
+    installProxyRuntime([webAccount]);
+    const fetchSpy = vi.fn(async (input: string, init: RequestInit) => {
+      const href = String(input);
+      expect(String((init.headers as Record<string, string>)['Cookie'])).toContain(
+        'sessionid=web-session'
+      );
+      if (href.includes('/canonical/')) {
+        return new Response(JSON.stringify({ status: 'ok', items: [] }), { status: 200 });
+      }
+      return new Response(null, {
+        status: 302,
+        headers: {
+          Location: 'https://i.instagram.com/api/v1/fbsearch/text_app/trends/canonical/'
+        }
+      });
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+    const res = await threadsPrivateApiRequest('fbsearch/text_app/trends/', {
+      credentialKey: 'key'
+    });
+    expect(res.ok).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy.mock.calls[0][1]).toMatchObject({ redirect: 'manual' });
+    expect(fetchSpy.mock.calls[1][1]).toMatchObject({ redirect: 'manual' });
+    expect(String(fetchSpy.mock.calls[1][0])).toBe(
+      'https://i.instagram.com/api/v1/fbsearch/text_app/trends/canonical/'
+    );
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Account-proxy `fetch()` calls sent session cookies with the default `redirect: 'follow'`. Cloudflare Workers forwards **all** headers (including `Cookie`) to a `Location` hop, even when that host is different.

`redirect: 'error'` is the spec-preferred refusal, but workerd rejects it (`Invalid redirect value, must be one of "follow" or "manual"`). Shared helper `fetchSameOriginHttps`:

- Sets `redirect: 'manual'` so fetch does not auto-follow.
- Follows a `Location` only when it is **HTTPS** and **same-origin** as the request URL.
- Leaves method, headers, body, and `withTimeout` signal handling unchanged.

Used by both Threads and Instagram private-API account proxies. Off-origin or `http:` redirects surface as the original 3xx (`ok: false`) instead of leaking the session.

Logged-out Instagram web fetches in `client.ts` are unchanged: they do not send credential-pool `sessionid` cookies.

## Test plan

- [x] Unit tests in `test/threads.accountProxy.test.ts`: off-origin 302 is not followed; `http:` same-host is not followed; same-origin HTTPS is followed with cookies and `redirect: 'manual'`.
- [x] Matching coverage in `test/instagram.accountProxy.test.ts`.
- [x] Helper tests in `test/sameOriginHttpsFetch.test.ts` (relative Location, protocol-relative, off-origin).
- [x] `npm run test -- test/threads.accountProxy.test.ts test/instagram.accountProxy.test.ts test/sameOriginHttpsFetch.test.ts` — 29 passed.
- [x] `npm run lint:eslint -w @fxembed/atmosphere` — clean.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c9c6a46-acc9-4a01-9dd3-6f48b9808548?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c9c6a46-acc9-4a01-9dd3-6f48b9808548&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

