### PR TITLE
fix(instagram): apply request timeout to private API body read

### DIFF
--- a/packages/atmosphere/src/providers/instagram/account-proxy.ts
+++ b/packages/atmosphere/src/providers/instagram/account-proxy.ts
@@ -150,15 +150,33 @@ export async function instagramPrivateApiRequest(
       headers['Content-Type'] = 'application/x-www-form-urlencoded';
     }
     let res: Response;
+    let text: string;
+    let parsed: unknown;
+    let parseFailed: boolean;
     try {
-      res = await withTimeout(signal =>
-        fetchSameOriginHttps(url.toString(), {
+      // Fetch can resolve on headers; keep body read + JSON.parse inside the timeout so a
+      // stalled body aborts and rotates instead of hanging the request.
+      const timed = await withTimeout(async signal => {
+        const response = await fetchSameOriginHttps(url.toString(), {
           method: options.method ?? 'GET',
           headers,
           body: options.method === 'POST' ? (options.body ?? '') : undefined,
           signal
-        })
-      );
+        });
+        if (!response.ok) {
+          return { response, text: '', parsed: null, parseFailed: false };
+        }
+        const body = await response.text();
+        try {
+          return { response, text: body, parsed: JSON.parse(body) as unknown, parseFailed: false };
+        } catch {
+          return { response, text: body, parsed: null, parseFailed: true };
+        }
+      });
+      res = timed.response;
+      text = timed.text;
+      parsed = timed.parsed;
+      parseFailed = timed.parseFailed;
     } catch (err) {
       console.error('[instagram] private API request threw', {
         path,
@@ -180,7 +198,6 @@ export async function instagramPrivateApiRequest(
       return last;
     }
 
-    const text = await res.text();
     const trimmed = text.trim();
     // A logged-out or checkpointed session gets an HTML login page rather than JSON.
     if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) {
@@ -191,10 +208,7 @@ export async function instagramPrivateApiRequest(
       last = { ok: false, status: res.status, json: null, accountUsed: account.username };
       continue;
     }
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(text) as unknown;
-    } catch {
+    if (parseFailed) {
       last = { ok: false, status: res.status, json: null, accountUsed: account.username };
       continue;
     }

--- a/test/instagram.accountProxy.test.ts
+++ b/test/instagram.accountProxy.test.ts
@@ -217,6 +217,60 @@ describe('instagram account proxy', () => {
     expect(res.json).toEqual({ status: 'fail', message: 'feedback_required' });
   });
 
+  it('keeps the HTTP status when JSON.parse fails and rotates', async () => {
+    installProxyRuntime([webAccount, androidAccount]);
+    const fetchSpy = vi.fn(async (_url: string, init: RequestInit) => {
+      const cookie = (init.headers as Record<string, string>)['Cookie'];
+      if (cookie.includes('web-session')) {
+        return new Response('{not json', { status: 200 });
+      }
+      return new Response(JSON.stringify({ status: 'ok' }), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+    const res = await instagramPrivateApiRequest('/media/1/info/', { credentialKey: 'key' });
+    expect(res.ok).toBe(true);
+    expect(res.accountUsed).toBe('android_account');
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports the HTTP status as last result when malformed JSON is the only response', async () => {
+    installProxyRuntime([webAccount]);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('{not json', { status: 200 }))
+    );
+    const res = await instagramPrivateApiRequest('/media/1/info/', { credentialKey: 'key' });
+    expect(res.ok).toBe(false);
+    expect(res.status).toBe(200);
+    expect(res.json).toBeNull();
+    expect(res.accountUsed).toBe('web_account');
+  });
+
+  it('rotates when the response body aborts inside the request timeout', async () => {
+    installProxyRuntime([webAccount, androidAccount]);
+    const fetchSpy = vi.fn(async (_url: string, init: RequestInit) => {
+      const cookie = (init.headers as Record<string, string>)['Cookie'];
+      if (cookie.includes('web-session')) {
+        return {
+          ok: true,
+          status: 200,
+          async text() {
+            const err = new Error('The operation was aborted');
+            err.name = 'AbortError';
+            throw err;
+          }
+        } as Response;
+      }
+      return new Response(JSON.stringify({ status: 'ok', items: [] }), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+    const res = await instagramPrivateApiRequest('/media/1/info/', { credentialKey: 'key' });
+    expect(res.ok).toBe(true);
+    expect(res.accountUsed).toBe('android_account');
+    // withTimeout retries the whole fetch+body read 4 times (initial + 3) before rotating.
+    expect(fetchSpy).toHaveBeenCalledTimes(5);
+  });
+
   it('does not auto-follow redirects and skips off-origin Location hops', async () => {
     installProxyRuntime([webAccount]);
     const fetchSpy = vi.fn(async (input: string) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- `instagramPrivateApiRequest` currently times out only the `fetch()` call. `fetch` can resolve when headers arrive, so a stalled `res.text()` hangs forever and never rotates accounts.
- Body read and `JSON.parse` now run inside the existing `withTimeout` callback. An incomplete body aborts, retries, then rotates — the same path Threads already uses.
- `status: 'fail'` detection and the successful JSON response contract are unchanged. Error HTTP statuses still skip the body read so 401/403/429 rotate immediately.

## Test plan
- `npm test -- test/instagram.accountProxy.test.ts`
- Covers HTML non-JSON rotation, `status: fail` rotation, malformed JSON last-result (`status` stays 200), and `AbortError` during `text()` rotating after `withTimeout` retries.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f609d2c4-a82b-4ae2-92e0-0d2f74b25b0a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f609d2c4-a82b-4ae2-92e0-0d2f74b25b0a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

