### PR TITLE
fix(embed): ignore Discord spoiler markers on translated URLs

### DIFF
--- a/packages/atmosphere/src/helpers/language.ts
+++ b/packages/atmosphere/src/helpers/language.ts
@@ -5,11 +5,11 @@ export const buildLanguageHeaders = (
   if (typeof language !== 'string') {
     return undefined;
   }
-  const cleaned = language.trim().toLowerCase();
-  if (cleaned.length === 0) {
+  const normalized = normalizeLanguage(language);
+  if (normalized.length === 0) {
     return undefined;
   }
-  return { 'x-twitter-client-language': normalizeLanguage(cleaned) };
+  return { 'x-twitter-client-language': normalized };
 };
 
 /**
@@ -38,8 +38,16 @@ export const isTranslatableLanguageCode = (language: string | null | undefined):
   return !NON_TRANSLATABLE_LANGUAGE_CODES.has(trimmed.toLowerCase());
 };
 
+/** Leading ISO language token (`en`, `zh-tw`, `zh-hant`). */
+const LANGUAGE_TOKEN = /^[a-z]{2,3}(?:-[a-z]{2,4})?/;
+
 export const normalizeLanguage = (language: string) => {
-  language = language.trim().toLowerCase();
+  // Discord spoiler-wrapped links append `||` to the path (`/status/id/en||`).
+  language = language.trim().toLowerCase().replace(/\|+/g, '');
+  const token = language.match(LANGUAGE_TOKEN);
+  if (token) {
+    language = token[0];
+  }
   switch (language) {
     case 'zh':
     case 'cn':

--- a/src/embed/status.ts
+++ b/src/embed/status.ts
@@ -97,6 +97,11 @@ export const handleStatus = async (
 ): Promise<Response> => {
   console.log('flags', JSON.stringify(flags));
 
+  if (typeof language === 'string') {
+    const normalized = normalizeLanguage(language);
+    language = normalized.length > 0 ? normalized : undefined;
+  }
+
   const isTelegram = (userAgent || '').indexOf('TelegramBot') > -1;
   const isDiscord = (userAgent || '').indexOf('Discordbot') > -1;
 
@@ -829,7 +834,7 @@ export const handleStatus = async (
       i: statusId
     };
     /* Convert necessary flags into snowcode data */
-    if (language !== status.lang) {
+    if (language && language !== status.lang) {
       data.l = language;
     }
     if (status.provider === DataProvider.Bluesky) {

--- a/test/bot.test.ts
+++ b/test/bot.test.ts
@@ -26,3 +26,33 @@ test('Status response robot (trailing slash/query string and extra characters)',
   );
   expect(result.status).toEqual(200);
 });
+
+test('Status response robot (Discord spoiler on translated URL)', async () => {
+  const result = await app.request(
+    new Request('https://fxtwitter.com/jack/status/20/en||', {
+      method: 'GET',
+      headers: botHeaders
+    }),
+    undefined,
+    harness
+  );
+  expect(result.status).toEqual(200);
+  const text = await result.text();
+  expect(text).not.toMatch(/Owie, you crashed/);
+  expect(text).toMatch(/application\/activity\+json/);
+});
+
+test('Status response robot (percent-encoded Discord spoiler on translated URL)', async () => {
+  const result = await app.request(
+    new Request('https://fxtwitter.com/jack/status/20/en%7C%7C', {
+      method: 'GET',
+      headers: botHeaders
+    }),
+    undefined,
+    harness
+  );
+  expect(result.status).toEqual(200);
+  const text = await result.text();
+  expect(text).not.toMatch(/Owie, you crashed/);
+  expect(text).toMatch(/application\/activity\+json/);
+});

--- a/test/bot.test.ts
+++ b/test/bot.test.ts
@@ -2,6 +2,7 @@ import { test, expect } from 'vitest';
 import { app } from '../src/worker';
 import { botHeaders } from './helpers/data';
 import harness from './helpers/harness';
+import { decodeSnowcode } from '../src/helpers/snowcode';
 
 test('Status response robot', async () => {
   const result = await app.request(
@@ -55,4 +56,23 @@ test('Status response robot (percent-encoded Discord spoiler on translated URL)'
   const text = await result.text();
   expect(text).not.toMatch(/Owie, you crashed/);
   expect(text).toMatch(/application\/activity\+json/);
+});
+
+test('Status response robot (Discord spoiler keeps translation language in activity snowcode)', async () => {
+  const result = await app.request(
+    new Request('https://fxtwitter.com/jack/status/20/zh-tw||', {
+      method: 'GET',
+      headers: botHeaders
+    }),
+    undefined,
+    harness
+  );
+  expect(result.status).toEqual(200);
+  const text = await result.text();
+  expect(text).not.toMatch(/Owie, you crashed/);
+  const match = text.match(/\/statuses\/(\d+)/);
+  expect(match?.[1]).toBeTruthy();
+  const decoded = decodeSnowcode(match?.[1] ?? '');
+  expect(decoded.i).toEqual('20');
+  expect(decoded.l).toEqual('zh-tw');
 });

--- a/test/language.test.ts
+++ b/test/language.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'vitest';
 import {
+  buildLanguageHeaders,
   isTranslatableLanguageCode,
   NON_TRANSLATABLE_LANGUAGE_CODES,
   normalizeLanguage,
@@ -32,6 +33,21 @@ test('isTranslatableLanguageCode rejects pseudo and unknown language codes', () 
   expect(isTranslatableLanguageCode('')).toBe(false);
   expect(isTranslatableLanguageCode(null)).toBe(false);
   expect(isTranslatableLanguageCode(undefined)).toBe(false);
+});
+
+test('normalizeLanguage strips Discord spoiler markers from language codes', () => {
+  expect(normalizeLanguage('en||')).toBe('en');
+  expect(normalizeLanguage('EN||')).toBe('en');
+  expect(normalizeLanguage('zh-tw||')).toBe('zh-tw');
+  expect(normalizeLanguage('zh-hant||')).toBe('zh-tw');
+  expect(normalizeLanguage('jp||')).toBe('ja');
+  expect(normalizeLanguage('en%7c%7c')).toBe('en');
+  expect(normalizeLanguage('||')).toBe('');
+});
+
+test('buildLanguageHeaders uses sanitized language codes', () => {
+  expect(buildLanguageHeaders('en||')).toEqual({ 'x-twitter-client-language': 'en' });
+  expect(buildLanguageHeaders('||')).toBeUndefined();
 });
 
 test('normalizeLanguage maps Traditional Chinese aliases to zh-tw', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #2264

Discord spoiler-wrapped links (`||https://fixupx.com/user/status/id/en||`) are fetched with trailing `||` on the path. That made the language param `en||`, and encoding it into the Discord activity snowcode threw (`Character not allowed: |`), which surfaced as the "Owie, you crashed FixupX" embed.

This change:
- Strips Discord spoiler markers from language codes in `normalizeLanguage` and keeps a leading ISO token (`en`, `zh-tw`, …)
- Applies that cleaned language in `handleStatus` before snowcode encoding so translation still works
- Adds unit tests plus Discord bot embed coverage for `/en||`, percent-encoded `%7C%7C`, and `/zh-tw||` (decoded activity snowcode still carries `l: "zh-tw"`)

## Testing
- `language.test.ts`: `en||`, `zh-tw||`, `jp||`, `%7c%7c`, empty `||`, and GraphQL language headers
- `bot.test.ts`: Discordbot requests to `/jack/status/20/en||`, `/en%7C%7C`, and `/zh-tw||` return 200 without the crash HTML; `/zh-tw||` keeps `zh-tw` in the activity snowcode

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed0b5352-a4ea-4bd1-85b2-9de05d9fd4bf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed0b5352-a4ea-4bd1-85b2-9de05d9fd4bf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language handling for translated status links, including Discord spoiler-wrapped and percent-encoded language codes.
  * Standardized language codes and aliases such as `jp` and `zh-hant` for more reliable localization.
  * Prevented invalid or empty language values from affecting translated status displays and activity metadata.

* **Tests**
  * Added coverage for sanitized language headers and translated status URLs, including verification that responses remain valid and error-free.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->